### PR TITLE
Load resources off scheme-independent URLs

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Ensure all resources are loaded using scheme-relative URLs.  Previously,
+  attempting to load off HTTP on HTTPS sites resulted in broken pages.
+  [davidjb]
 - Plone 3.x is not officially supported anymore; use it at your own risk.
   [hvelarde]
 

--- a/sc/social/like/browser/templates/metadata.pt
+++ b/sc/social/like/browser/templates/metadata.pt
@@ -9,13 +9,13 @@
     </tal:cond>
     <meta tal:condition="view/fbadmins" property="fb:admins" tal:attributes="content view/fbadmins" />
     <script
-        tal:attributes="src string:http://connect.facebook.net/${view/language}/all.js#xfbml=1"
-        src="http://connect.facebook.net/en_US/all.js#xfbml=1"></script>
+        tal:attributes="src string://connect.facebook.net/${view/language}/all.js#xfbml=1"
+        src="//connect.facebook.net/en_US/all.js#xfbml=1"></script>
   </tal:fb>
   <tal:gp  tal:condition="view/gp_enabled">
 
   <script tal:attributes="type string:text/javascript;
-                          src string:http://apis.google.com/js/plusone.js">
+                          src string://apis.google.com/js/plusone.js">
   </script>
 
   <script type="text/javascript" tal:content="view/get_params">

--- a/sc/social/like/browser/templates/sociallikes.pt
+++ b/sc/social/like/browser/templates/sociallikes.pt
@@ -9,8 +9,8 @@
         </tal:block>
     </tal:gp>
     <tal:twitter tal:condition="view/twitter_enabled">
-        <script src="http://platform.twitter.com/widgets.js" type="text/javascript"></script>
-        <a href="http://twitter.com/share" class="twitter-share-button" tal:attributes="data-count view/typebutton;
+        <script src="//platform.twitter.com/widgets.js" type="text/javascript"></script>
+        <a href="//twitter.com/share" class="twitter-share-button" tal:attributes="data-count view/typebutton;
                                                                                         data-via view/twittvia;
                                                                                         data-url here/absolute_url;
                                                                                         data-lang view/language;


### PR DESCRIPTION
Previously, loading a page on HTTPS caused resources to fail to load since they were being loaded from http:// URLs.  

All resources from external share APIs are available on both protocols, so this ensures pages will always load correctly.
