### PR TITLE
Add possibility to activate 'Share' with facebook button

### DIFF
--- a/sc/social/like/browser/stylesheets/social_like.css
+++ b/sc/social/like/browser/stylesheets/social_like.css
@@ -1,5 +1,17 @@
 #viewlet-social-like {margin-top: 5px;}
 #viewlet-social-like .twitter-count-horizontal {height: 20px !important;}
 #viewlet-social-like .fb_edge_widget_with_comment {position: relative; margin-top: 0px;}
-.twitter-share-button {margin-top: 0.8px;}
-.horizontal .fb_iframe_widget iframe {height: 23px !important;}
+
+#viewlet-social-like ul.like-buttons{
+float: left;
+list-style: none;
+margin: 5px 0 5px 0;
+padding: 0;
+width: 100%;
+list-style-type: none;
+}
+
+#viewlet-social-like ul.like-buttons li{
+    display: block;
+    float: left;
+}

--- a/sc/social/like/browser/templates/sociallikes.pt
+++ b/sc/social/like/browser/templates/sociallikes.pt
@@ -14,40 +14,29 @@
         <li class="twitter-like" tal:condition="view/twitter_enabled">
             <script src="//platform.twitter.com/widgets.js" type="text/javascript"></script>
             <a href="//twitter.com/share" class="twitter-share-button" tal:attributes="data-count view/typebutton;
-                                                                                            data-via view/twittvia;
-                                                                                            data-url here/absolute_url;
-                                                                                            data-lang view/language;
-                                                                                            data-text here/Title;">Tweet</a>
+                                                                                       data-via view/twittvia;
+                                                                                       data-lang view/language;
+                                                                                       data-text here/Title;">Tweet</a>
         </li>
 
         <li class="fb-like" tal:condition="view/fb_enabled">
 
-            <tal:buttontype tal:condition="python:view.fb_typebutton == 'like'"
-                            tal:define="button python:{'vertical':'box_count','horizontal':'button_count'};
-                                        vbutton view/typebutton">
-                <iframe tal:attributes="src python:'https://www.facebook.com/plugins/like.php?locale=%s&href=%s&amp;send=false&amp;layout=%s&amp;show_faces=true&amp;action=%s' %(view.language,here.absolute_url(),button[str(vbutton)],view.fbaction)"
-                style="border:none; overflow:hidden; height:21px;"></iframe>
-            </tal:buttontype>
+            <div id="fb-root"></div>
+            <script>(function(d, s, id) {
+                var js, fjs = d.getElementsByTagName(s)[0];
+                if (d.getElementById(id)) return;
+                js = d.createElement(s); js.id = id;
+                js.src = "//connect.facebook.net/fr_FR/all.js#xfbml=1&appId=321358197994003";
+                fjs.parentNode.insertBefore(js, fjs);
+                }(document, 'script', 'facebook-jssdk'));</script>
 
-            <tal:buttontype tal:condition="python:view.fb_typebutton == 'share_this'">
-                <div id="fb-root"></div>
-                <script>(function(d, s, id) {
-                    var js, fjs = d.getElementsByTagName(s)[0];
-                    if (d.getElementById(id)) return;
-                    js = d.createElement(s); js.id = id;
-                    js.src = "//connect.facebook.net/fr_FR/all.js#xfbml=1&appId=321358197994003";
-                    fjs.parentNode.insertBefore(js, fjs);
-                    }(document, 'script', 'facebook-jssdk'));</script>
-
-                <div class="fb-like"
-                     data-href=""
-                     data-send="true"
-                     data-layout="button_count"
-                     data-width=""
-                     data-show-faces="false"
-                     data-font="arial"
-                     tal:attributes="data-href here/absolute_url"></div>
-            </tal:buttontype>
+            <div class="fb-like"
+                 data-layout="button_count"
+                 data-show-faces="false"
+                 data-font="arial"
+                 data-send=""
+                 data-width=""
+                 tal:attributes="data-send python: view.fb_typebutton == 'share_this' and 'true' or 'false'"></div>
 
         </li>
     </ul>

--- a/sc/social/like/browser/templates/sociallikes.pt
+++ b/sc/social/like/browser/templates/sociallikes.pt
@@ -1,35 +1,54 @@
 <div id="viewlet-social-like"
      tal:attributes="class view/typebutton"
-     style="display:none" i18n:domain="sc.social.like" tal:condition="view/enabled">
-    <tal:gp tal:condition="view/gp_enabled">
-        <tal:block tal:define="button python:{'vertical':'tall','horizontal':'medium'}; vbutton view/typebutton">
-          <div id="plusonebt"></div>
-          <script type="text/javascript" tal:content="python:'''\n jQuery(document).ready(function(){ \n gapi.plusone.render('plusonebt',{'size': '%s','annotation': 'bubble'}) \n }); ''' %(button[str(vbutton)])" >
-          </script>
-        </tal:block>
-    </tal:gp>
-    <tal:twitter tal:condition="view/twitter_enabled">
-        <script src="//platform.twitter.com/widgets.js" type="text/javascript"></script>
-        <a href="//twitter.com/share" class="twitter-share-button" tal:attributes="data-count view/typebutton;
-                                                                                        data-via view/twittvia;
-                                                                                        data-url here/absolute_url;
-                                                                                        data-lang view/language;
-                                                                                        data-text here/Title;">Tweet</a>
-    </tal:twitter>
-    <tal:fb
-        tal:condition="view/fb_enabled"
-        tal:define="button python:{'vertical':'box_count','horizontal':'button_count'};
-                           vbutton view/typebutton">
-        <iframe tal:attributes="src python:'https://www.facebook.com/plugins/like.php?locale=%s&href=%s&amp;send=false&amp;layout=%s&amp;show_faces=true&amp;action=%s' %(view.language,here.absolute_url(),button[str(vbutton)],view.fbaction)"
-         style="border:none; overflow:hidden; height:21px;"></iframe>
-    </tal:fb>
-</div>
+     i18n:domain="sc.social.like" tal:condition="view/enabled">
 
-<script type="text/javascript" tal:condition="view/enabled">
-    jQuery(function () {
-        jQuery("div#viewlet-social-like").each(function(){
-            jQuery(this).fadeIn(3000);
-            jQuery(this).removeAttr("style");
-        });
-    });
-</script>
+    <ul class="like-buttons">
+        <li class="g-plus-one" tal:condition="view/gp_enabled">
+            <tal:block tal:define="button python:{'vertical':'tall','horizontal':'medium'}; vbutton view/typebutton">
+            <div id="plusonebt"></div>
+            <script type="text/javascript" tal:content="python:'''\n jQuery(document).ready(function(){ \n gapi.plusone.render('plusonebt',{'size': '%s','annotation': 'bubble'}) \n }); ''' %(button[str(vbutton)])" >
+            </script>
+            </tal:block>
+        </li>
+
+        <li class="twitter-like" tal:condition="view/twitter_enabled">
+            <script src="//platform.twitter.com/widgets.js" type="text/javascript"></script>
+            <a href="//twitter.com/share" class="twitter-share-button" tal:attributes="data-count view/typebutton;
+                                                                                            data-via view/twittvia;
+                                                                                            data-url here/absolute_url;
+                                                                                            data-lang view/language;
+                                                                                            data-text here/Title;">Tweet</a>
+        </li>
+
+        <li class="fb-like" tal:condition="view/fb_enabled">
+
+            <tal:buttontype tal:condition="python:view.fb_typebutton == 'like'"
+                            tal:define="button python:{'vertical':'box_count','horizontal':'button_count'};
+                                        vbutton view/typebutton">
+                <iframe tal:attributes="src python:'https://www.facebook.com/plugins/like.php?locale=%s&href=%s&amp;send=false&amp;layout=%s&amp;show_faces=true&amp;action=%s' %(view.language,here.absolute_url(),button[str(vbutton)],view.fbaction)"
+                style="border:none; overflow:hidden; height:21px;"></iframe>
+            </tal:buttontype>
+
+            <tal:buttontype tal:condition="python:view.fb_typebutton == 'share_this'">
+                <div id="fb-root"></div>
+                <script>(function(d, s, id) {
+                    var js, fjs = d.getElementsByTagName(s)[0];
+                    if (d.getElementById(id)) return;
+                    js = d.createElement(s); js.id = id;
+                    js.src = "//connect.facebook.net/fr_FR/all.js#xfbml=1&appId=321358197994003";
+                    fjs.parentNode.insertBefore(js, fjs);
+                    }(document, 'script', 'facebook-jssdk'));</script>
+
+                <div class="fb-like"
+                     data-href=""
+                     data-send="true"
+                     data-layout="button_count"
+                     data-width=""
+                     data-show-faces="false"
+                     data-font="arial"
+                     tal:attributes="data-href here/absolute_url"></div>
+            </tal:buttontype>
+
+        </li>
+    </ul>
+</div>

--- a/sc/social/like/browser/viewlets.py
+++ b/sc/social/like/browser/viewlets.py
@@ -50,6 +50,7 @@ class BaseLikeViewlet(ViewletBase):
     twitter_enabled = False
     twittvia = ''
     fb_enabled = False
+    fb_typebutton = ''
     fbaction = ''
     fbadmins = ''
     gp_enabled = False
@@ -74,6 +75,7 @@ class BaseLikeViewlet(ViewletBase):
             self.twitter_enabled = self.sheet.getProperty("twitter_enabled", True)
             self.twittvia = self.sheet.getProperty("twittvia", "")
             self.fb_enabled = self.sheet.getProperty("fb_enabled", True)
+            self.fb_typebutton = self.sheet.getProperty("fb_typebutton", "")
             self.fbaction = self.sheet.getProperty("fbaction", "")
             self.fbadmins = self.sheet.getProperty("fbadmins", "")
             self.gp_enabled = self.sheet.getProperty("gp_enabled", True)

--- a/sc/social/like/controlpanel/likes.py
+++ b/sc/social/like/controlpanel/likes.py
@@ -23,6 +23,11 @@ from sc.social.like import LikeMessageFactory as _
 
 from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
 
+buttonTypes = SimpleVocabulary([
+    SimpleTerm(value=u'like', title=_(u'Like')),
+    SimpleTerm(value=u'share_this', title=_(u'Share this')),
+])
+
 verbs = SimpleVocabulary([
     SimpleTerm(value=u'like', title=_(u'Like')),
     SimpleTerm(value=u'recommend', title=_(u'Recommend')),
@@ -90,13 +95,21 @@ class IFbSchema(Interface):
         required=False,
     )
 
+    fb_typebutton = Choice(
+        title=_(u"Choose the type of button you want"),
+        required=True,
+        default=u'like',
+        vocabulary=buttonTypes,
+    )
+
     fbaction = Choice(
         title=_(u'Verb to display'),
         description=_(
             u'help_verb_display',
             default=u"The verb to display in the facebook button. "
                     u"Currently only 'like' and 'recommend' are "
-                    u"supported.",
+                    u"supported."
+                    u"Only used for 'Like' button type.",
         ),
         required=True,
         default=u'like',
@@ -158,6 +171,7 @@ class FbControlPanelAdapter(BaseControlPanelAdapter):
     implements(IFbSchema)
 
     fb_enabled = ProxyFieldProperty(IFbSchema['fb_enabled'])
+    fb_typebutton = ProxyFieldProperty(IFbSchema['fb_typebutton'])
     fbaction = ProxyFieldProperty(IFbSchema['fbaction'])
     fbadmins = ProxyFieldProperty(IFbSchema['fbadmins'])
 

--- a/sc/social/like/profiles/default/propertiestool.xml
+++ b/sc/social/like/profiles/default/propertiestool.xml
@@ -11,6 +11,7 @@
       <property name="twitter_enabled" type="boolean">True</property>
       <property name="twittvia" type="string" purge="False"></property>
       <property name="fb_enabled" type="boolean">True</property>      
+      <property name="fb_typebutton" type="string" purge="False"></property>
       <property name="fbaction" type="string" purge="False"></property>
       <property name="fbadmins" type="string" purge="False"></property>
       <property name="gp_enabled" type="boolean">True</property>      

--- a/sc/social/like/profiles/to2000/propertiestool.xml
+++ b/sc/social/like/profiles/to2000/propertiestool.xml
@@ -10,6 +10,7 @@
       <property name="twitter_enabled" type="boolean">True</property>
       <property name="twittvia" type="string" purge="False"></property>
       <property name="fb_enabled" type="boolean">True</property>      
+      <property name="fb_typebutton" type="string" purge="False"></property>
       <property name="fbaction" type="string" purge="False"></property>
       <property name="fbadmins" type="string" purge="False"></property>
       <property name="gp_enabled" type="boolean">False</property>      


### PR DESCRIPTION
Right now we just can show a 'Like' type facebook button, it is interesting to add the possibility tu add the 'Share' button. This pull request add possibility to add the 'share' button by an option in the control panel.

It also remove the url 'hardcoded' in the viewlet and let take the informations from collective.opengraph og:url property.