### PR TITLE
Social stuff on real view only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ There's a frood who really knows where his towel is.
 2.0rc2 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Do not load social media stuff on non-canonical views
+  (like edit form or similar). This close `#36`__.
+  [keul]
+  
+  __ https://github.com/collective/sc.social.like/issues/36
+
 - Added italian translation.
   [keul]
 

--- a/sc/social/like/browser/helper.py
+++ b/sc/social/like/browser/helper.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+
 from Acquisition import aq_inner
+from Products.Five import BrowserView
+from plone.app.layout.globals.interfaces import IViewView
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
-from Products.Five import BrowserView
 from sc.social.like.controlpanel.likes import LikeControlPanelAdapter
 from sc.social.like.interfaces import IHelperView
 from sc.social.like.plugins import IPlugin
@@ -42,7 +44,9 @@ class HelperView(BrowserView):
         return configs.plugins_enabled or []
 
     @memoize
-    def enabled(self):
+    def enabled(self, view=None):
+        if view and not IViewView.providedBy(view):
+            return False
         enabled_portal_types = self.enabled_portal_types()
         return self.context.portal_type in enabled_portal_types
 

--- a/sc/social/like/browser/viewlets.py
+++ b/sc/social/like/browser/viewlets.py
@@ -15,6 +15,7 @@ class BaseLikeViewlet(ViewletBase):
         super(BaseLikeViewlet, self).__init__(context, request, view, manager)
         self.context = context
         self.request = request
+        self.view = view
         self.helper = getMultiAdapter((self.context, self.request),
                                       name=u'sl_helper')
         self.typebutton = self.helper.typebutton()
@@ -60,8 +61,7 @@ class SocialMetadataViewlet(BaseLikeViewlet):
         # contained content types
         if template in ('all_content', 'folder_full_view',):
             return True
-        else:
-            return super(SocialMetadataViewlet, self).enabled()
+        return self.helper.enabled(self.view)
 
 
 class SocialLikesViewlet(BaseLikeViewlet):

--- a/sc/social/like/interfaces/socialikes.py
+++ b/sc/social/like/interfaces/socialikes.py
@@ -28,8 +28,11 @@ class IHelperView(Interface):
     def typebutton():
         ''' Button to be used '''
 
-    def enabled():
-        ''' Social Like is enabled for this context '''
+    def enabled(view):
+        '''
+        Social Like is enabled for this context and provided view
+        (when provided)
+        '''
 
     def available_plugins():
         ''' Return available plugins '''

--- a/sc/social/like/tests/test_viewlets.py
+++ b/sc/social/like/tests/test_viewlets.py
@@ -43,6 +43,12 @@ class MetadataViewletTestCase(unittest.TestCase):
         viewlet = self.viewlet(self.document)
         self.assertTrue(viewlet.enabled())
 
+    def test_disabled_on_edit_document(self):
+        request = self.layer['request']
+        request.set('ACTUAL_URL', self.document.absolute_url() + '/edit')
+        html = self.document.atct_edit()
+        self.assertFalse('og:site_name' in html)
+
     def test_render(self):
         viewlet = self.viewlet(self.document)
         html = viewlet.render()
@@ -75,6 +81,12 @@ class LikeViewletTestCase(unittest.TestCase):
     def test_enabled_on_document(self):
         viewlet = self.viewlet(self.document)
         self.assertTrue(viewlet.enabled())
+
+    def test_disabled_on_edit_document(self):
+        request = self.layer['request']
+        request.set('ACTUAL_URL', self.document.absolute_url() + '/edit')
+        html = self.document.atct_edit()
+        self.assertFalse('id="viewlet-social-like"' in html)
 
     def test_render(self):
         viewlet = self.viewlet(self.document)


### PR DESCRIPTION
This close #36 

Solution was not super-easy as sc.social.like has the "full_document" feature so the normal usage of `view` zcml attribute fro `browser:viewlet` is not used but the enabled/disabled logic is on python code.

Until now no one suffered this issue because on views different from `IViewView` the `IBelowContentTitle` is *not* shown. This is not true for `IHtmlHead` viewlets that are always there.

Solution: the `enabled` method now accept an optional `view` parameter.

