### PR TITLE
Add Facebook control panel setting for showing/hiding the number of likes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ There's a frood who really knows where his towel is.
 2.8b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Add Facebook control panel setting for showing/hiding the number of likes. By
+  default the Facebook plugin still shows the likes.
+  [fredvd]
 
 
 2.8b1 (2017-02-03)

--- a/sc/social/like/interfaces.py
+++ b/sc/social/like/interfaces.py
@@ -110,7 +110,7 @@ class ISocialLikeSettings(model.Schema):
     model.fieldset(
         'facebook',
         label=u'Facebook',
-        fields=['fbaction', 'facebook_username', 'facebook_app_id', 'fbbuttons'],
+        fields=['fbaction', 'facebook_username', 'facebook_app_id', 'fbbuttons', 'fbshowlikes'],
     )
 
     fbaction = schema.Choice(
@@ -157,6 +157,16 @@ class ISocialLikeSettings(model.Schema):
         value_type=schema.Choice(vocabulary=FacebookButtonsVocabulary),
         required=True,
         default=(u'Like', ),
+    )
+
+    fbshowlikes = schema.Bool(
+        title=_(u'Show number of likes'),
+        description=_(
+            u'help_show_likes',
+            default=u'If enabled, the facebook button will show the number of '
+                    u'facebook users who have already liked this page.'
+        ),
+        default=True,
     )
 
     model.fieldset(

--- a/sc/social/like/locales/de/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/de/LC_MESSAGES/sc.social.like.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social 2.2\n"
-"POT-Creation-Date: 2017-03-06 14:08+0000\n"
+"POT-Creation-Date: 2017-03-06 16:27+0000\n"
 "PO-Revision-Date: 2015-05-29 09:50 +0002\n"
 "Last-Translator: Toni Fischer <tf@zettwerk.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,314 +14,314 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: sc.social.like\n"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr ""
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr ""
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr ""
 
-#: ../tiles/twitter.py:86
+#: ./sc/social/like/tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr ""
 
-#: ../interfaces.py:130
+#: ./sc/social/like/interfaces.py:130
 msgid "Admins"
 msgstr "Administratoren"
 
-#: ../interfaces.py:141
+#: ./sc/social/like/interfaces.py:141
 msgid "Application ID"
 msgstr "App ID"
 
-#: ../interfaces.py:87
+#: ./sc/social/like/interfaces.py:87
 msgid "Button style"
 msgstr "Stil der Buttons"
 
-#: ../interfaces.py:63
+#: ./sc/social/like/interfaces.py:63
 msgid "Content types"
 msgstr "Inhaltstypen"
 
-#: ../tiles/twitter.py:26
+#: ./sc/social/like/tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ../tiles/twitter.py:74
+#: ./sc/social/like/tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ../interfaces.py:98
+#: ./sc/social/like/interfaces.py:98
 msgid "Do not track users"
 msgstr ""
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ../tiles/facebook.py:25
+#: ./sc/social/like/tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ../tiles/facebook.py:35
+#: ./sc/social/like/tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ../interfaces.py:152
+#: ./sc/social/like/interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Facebook Buttons"
 
-#: ../tiles/facebook.py:53
-#: ../tiles/twitter.py:54
+#: ./sc/social/like/tiles/facebook.py:53
+#: ./sc/social/like/tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ../tiles/facebook.py:72
+#: ./sc/social/like/tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ../tiles/facebook.py:82
+#: ./sc/social/like/tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ../tiles/twitter.py:24
+#: ./sc/social/like/tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ../tiles/twitter.py:23
+#: ./sc/social/like/tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ../vocabularies.py:41
+#: ./sc/social/like/vocabularies.py:41
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: ../tiles/facebook.py:26
+#: ./sc/social/like/tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ../plugins/pinterest/templates/link.pt:11
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr ""
 
-#: ../plugins/pinterest/templates/link.pt:3
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr ""
 
-#: ../interfaces.py:76
+#: ./sc/social/like/interfaces.py:76
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../vocabularies.py:42
+#: ./sc/social/like/vocabularies.py:42
 msgid "Recommend"
 msgstr "Empfehlen"
 
-#: ../tiles/twitter.py:25
+#: ./sc/social/like/tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr ""
 
-#: ../tiles/twitter.py:27
+#: ./sc/social/like/tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr ""
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ../tiles/twitter.py:55
+#: ./sc/social/like/tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr ""
 
-#: ../tiles/facebook.py:54
+#: ./sc/social/like/tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr ""
 
-#: ../tiles/facebook.py:42
+#: ./sc/social/like/tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ../tiles/twitter.py:43
+#: ./sc/social/like/tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ../controlpanel.py:13
+#: ./sc/social/like/controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ../plugins/telegram/plugin.pt:2
-#: ../plugins/whatsapp/templates/plugin.pt:2
-#: ../vocabularies.py:47
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/vocabularies.py:47
 msgid "Share"
 msgstr "Teilen"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr ""
 
-#: ../plugins/facebook/templates/link.pt:12
+#: ./sc/social/like/plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr ""
 
-#: ../plugins/facebook/templates/link.pt:6
+#: ./sc/social/like/plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr ""
 
-#: ../plugins/gplus/templates/link.pt:9
+#: ./sc/social/like/plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr ""
 
-#: ../plugins/gplus/templates/link.pt:3
+#: ./sc/social/like/plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr ""
 
-#: ../plugins/linkedin/templates/link.pt:9
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr ""
 
-#: ../plugins/linkedin/templates/link.pt:3
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr ""
 
-#: ../plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr ""
 
-#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "In WhatsApp mitteilen"
 
-#: ../interfaces.py:163
+#: ./sc/social/like/interfaces.py:163
 msgid "Show number of likes"
 msgstr ""
 
-#: ../tiles/facebook.py:77
+#: ./sc/social/like/tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr ""
 
-#: ../tiles/facebook.py:87
+#: ./sc/social/like/tiles/facebook.py:87
 msgid "Show small header"
 msgstr ""
 
-#: ../controlpanel.py:12
-#: ../profiles/default/controlpanel.xml
+#: ./sc/social/like/controlpanel.py:12
+#: ./sc/social/like/profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: Like Aktionen"
 
-#: ../tiles/facebook.py:36
+#: ./sc/social/like/tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr ""
 
-#: ../tiles/facebook.py:24
+#: ./sc/social/like/tiles/facebook.py:24
 msgid "Timeline"
 msgstr ""
 
-#: ../plugins/twitter/templates/link.pt:9
+#: ./sc/social/like/plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr ""
 
-#: ../plugins/twitter/templates/link.pt:3
+#: ./sc/social/like/plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr ""
 
-#: ../tiles/twitter.py:73
+#: ./sc/social/like/tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr ""
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr ""
 
-#: ../interfaces.py:176
+#: ./sc/social/like/interfaces.py:176
 msgid "Twitter nick"
 msgstr "Twitter Name"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ../interfaces.py:117
+#: ./sc/social/like/interfaces.py:117
 msgid "Verb to display"
 msgstr "Angezeigtes Wort"
 
-#: ../tiles/twitter.py:85
+#: ./sc/social/like/tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr ""
 
-#: ../tiles/twitter.py:36
+#: ./sc/social/like/tiles/twitter.py:36
 msgid "Widget ID"
 msgstr ""
 
-#: ../tiles/facebook.py:41
-#: ../tiles/twitter.py:42
+#: ./sc/social/like/tiles/facebook.py:41
+#: ./sc/social/like/tiles/twitter.py:42
 msgid "Width"
 msgstr ""
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ../interfaces.py:131
+#: ./sc/social/like/interfaces.py:131
 msgid "help_admins"
 msgstr "Eine Komma getrennte Liste von entweder den Facebook IDs der Seiten-Administratoren oder der Facebook App ID."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ../interfaces.py:142
+#: ./sc/social/like/interfaces.py:142
 #, fuzzy
 msgid "help_appid"
 msgstr "Eine Facebook App ID."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ../interfaces.py:99
+#: ./sc/social/like/interfaces.py:99
 msgid "help_do_not_track"
 msgstr ""
 
 #. Default: "Please select which plugins will be used"
-#: ../interfaces.py:77
+#: ./sc/social/like/interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Die gewünschten Plugins auswählen"
 
 #. Default: "Select buttons to be shown"
-#: ../interfaces.py:153
+#: ./sc/social/like/interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Welche Buttons sollen angezeigt werden?"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ../interfaces.py:64
+#: ./sc/social/like/interfaces.py:64
 msgid "help_portal_types"
 msgstr "Die Inhaltstypen auswählen auf denen das Viewlet angezeigt werden soll."
 
 #. Default: "Choose your button style."
-#: ../interfaces.py:88
+#: ./sc/social/like/interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Wählen Sie den gewünschten Stil für die Buttons aus."
 
 #. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
-#: ../interfaces.py:164
+#: ./sc/social/like/interfaces.py:164
 msgid "help_show_likes"
 msgstr ""
 
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ../interfaces.py:118
+#: ./sc/social/like/interfaces.py:118
 msgid "help_verb_display"
 msgstr "Der Ausdruck, welcher im Facebook Button angezeigt werden soll. Zurzeit werden nur \"Gefällt mir\" und \"Empfehlen\" unterstützt."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ../interfaces.py:177
+#: ./sc/social/like/interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Geben Sie Ihren Twitter Namen ein z.B. mmustermann."
 
-#: ../vocabularies.py:35
+#: ./sc/social/like/vocabularies.py:35
 msgid "horizontal"
 msgstr "horizontal"
 
-#: ../vocabularies.py:36
+#: ./sc/social/like/vocabularies.py:36
 msgid "vertical"
 msgstr "vertikal"

--- a/sc/social/like/locales/de/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/de/LC_MESSAGES/sc.social.like.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social 2.2\n"
-"POT-Creation-Date: 2017-02-01 18:40+0000\n"
+"POT-Creation-Date: 2017-03-06 14:08+0000\n"
 "PO-Revision-Date: 2015-05-29 09:50 +0002\n"
 "Last-Translator: Toni Fischer <tf@zettwerk.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,305 +14,314 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: sc.social.like\n"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:86
+#: ../tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:130
+#: ../interfaces.py:130
 msgid "Admins"
 msgstr "Administratoren"
 
-#: ./sc/social/like/interfaces.py:141
+#: ../interfaces.py:141
 msgid "Application ID"
 msgstr "App ID"
 
-#: ./sc/social/like/interfaces.py:87
+#: ../interfaces.py:87
 msgid "Button style"
 msgstr "Stil der Buttons"
 
-#: ./sc/social/like/interfaces.py:63
+#: ../interfaces.py:63
 msgid "Content types"
 msgstr "Inhaltstypen"
 
-#: ./sc/social/like/tiles/twitter.py:26
+#: ../tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:74
+#: ../tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:98
+#: ../interfaces.py:98
 msgid "Do not track users"
 msgstr ""
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:25
+#: ../tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:35
+#: ../tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:152
+#: ../interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Facebook Buttons"
 
-#: ./sc/social/like/tiles/facebook.py:53
-#: ./sc/social/like/tiles/twitter.py:54
+#: ../tiles/facebook.py:53
+#: ../tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:72
+#: ../tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:82
+#: ../tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:24
+#: ../tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:23
+#: ../tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:41
+#: ../vocabularies.py:41
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: ./sc/social/like/tiles/facebook.py:26
+#: ../tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
+#: ../plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
+#: ../plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:76
+#: ../interfaces.py:76
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ./sc/social/like/vocabularies.py:42
+#: ../vocabularies.py:42
 msgid "Recommend"
 msgstr "Empfehlen"
 
-#: ./sc/social/like/tiles/twitter.py:25
+#: ../tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:27
+#: ../tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr ""
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:55
+#: ../tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:54
+#: ../tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:42
+#: ../tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:43
+#: ../tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ./sc/social/like/controlpanel.py:13
+#: ../controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
-#: ./sc/social/like/vocabularies.py:47
+#: ../plugins/telegram/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ../vocabularies.py:47
 msgid "Share"
 msgstr "Teilen"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr ""
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:12
+#: ../plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr ""
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:6
+#: ../plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:9
+#: ../plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr ""
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:3
+#: ../plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
+#: ../plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr ""
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
+#: ../plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ../plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr ""
 
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "In WhatsApp mitteilen"
 
-#: ./sc/social/like/tiles/facebook.py:77
+#: ../interfaces.py:163
+msgid "Show number of likes"
+msgstr ""
+
+#: ../tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:87
+#: ../tiles/facebook.py:87
 msgid "Show small header"
 msgstr ""
 
-#: ./sc/social/like/controlpanel.py:12
-#: ./sc/social/like/profiles/default/controlpanel.xml
+#: ../controlpanel.py:12
+#: ../profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: Like Aktionen"
 
-#: ./sc/social/like/tiles/facebook.py:36
+#: ../tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:24
+#: ../tiles/facebook.py:24
 msgid "Timeline"
 msgstr ""
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:9
+#: ../plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr ""
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:3
+#: ../plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:73
+#: ../tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:166
+#: ../interfaces.py:176
 msgid "Twitter nick"
 msgstr "Twitter Name"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:117
+#: ../interfaces.py:117
 msgid "Verb to display"
 msgstr "Angezeigtes Wort"
 
-#: ./sc/social/like/tiles/twitter.py:85
+#: ../tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:36
+#: ../tiles/twitter.py:36
 msgid "Widget ID"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:41
-#: ./sc/social/like/tiles/twitter.py:42
+#: ../tiles/facebook.py:41
+#: ../tiles/twitter.py:42
 msgid "Width"
 msgstr ""
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ./sc/social/like/interfaces.py:131
+#: ../interfaces.py:131
 msgid "help_admins"
 msgstr "Eine Komma getrennte Liste von entweder den Facebook IDs der Seiten-Administratoren oder der Facebook App ID."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ./sc/social/like/interfaces.py:142
+#: ../interfaces.py:142
 #, fuzzy
 msgid "help_appid"
 msgstr "Eine Facebook App ID."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ./sc/social/like/interfaces.py:99
+#: ../interfaces.py:99
 msgid "help_do_not_track"
 msgstr ""
 
 #. Default: "Please select which plugins will be used"
-#: ./sc/social/like/interfaces.py:77
+#: ../interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Die gewünschten Plugins auswählen"
 
 #. Default: "Select buttons to be shown"
-#: ./sc/social/like/interfaces.py:153
+#: ../interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Welche Buttons sollen angezeigt werden?"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ./sc/social/like/interfaces.py:64
+#: ../interfaces.py:64
 msgid "help_portal_types"
 msgstr "Die Inhaltstypen auswählen auf denen das Viewlet angezeigt werden soll."
 
 #. Default: "Choose your button style."
-#: ./sc/social/like/interfaces.py:88
+#: ../interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Wählen Sie den gewünschten Stil für die Buttons aus."
 
+#. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
+#: ../interfaces.py:164
+msgid "help_show_likes"
+msgstr ""
+
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ./sc/social/like/interfaces.py:118
+#: ../interfaces.py:118
 msgid "help_verb_display"
 msgstr "Der Ausdruck, welcher im Facebook Button angezeigt werden soll. Zurzeit werden nur \"Gefällt mir\" und \"Empfehlen\" unterstützt."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ./sc/social/like/interfaces.py:167
+#: ../interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Geben Sie Ihren Twitter Namen ein z.B. mmustermann."
 
-#: ./sc/social/like/vocabularies.py:35
+#: ../vocabularies.py:35
 msgid "horizontal"
 msgstr "horizontal"
 
-#: ./sc/social/like/vocabularies.py:36
+#: ../vocabularies.py:36
 msgid "vertical"
 msgstr "vertikal"

--- a/sc/social/like/locales/es/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/es/LC_MESSAGES/sc.social.like.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social.like\n"
-"POT-Creation-Date: 2017-02-01 18:40+0000\n"
+"POT-Creation-Date: 2017-03-06 14:08+0000\n"
 "PO-Revision-Date: 2017-02-01 16:38-0200\n"
 "Last-Translator: Héctor Velarde <hector.velarde@gmail.com>\n"
 "Language-Team: Simples Consultoria <products@simplesconsultoria.com.br>\n"
@@ -19,305 +19,314 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr "Una integración sencilla, pero útil, de redes sociales con Plone."
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr "Tile para integrar una página de Facebook."
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr "Tile para integrar una línea de tiempo de Twitter."
 
-#: ./sc/social/like/tiles/twitter.py:86
+#: ../tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr "Un widget de línea de tiempo es una región en una página que puede recibir actualizaciones a medida que nuevos tweets estén disponibles. Cuando se especifica polite, las tecnologías de asistencia notificarán a los usuarios de las actualizaciones, pero no interrumpirán de manera general la tarea actual y las actualizaciones tendrán poca prioridad. Cuando se especifica assertive, las tecnologías de asistencia notificarán inmediatamente al usuario y podrían eliminar la cola de mensajes de las actualizaciones anteriores."
 
-#: ./sc/social/like/interfaces.py:130
+#: ../interfaces.py:130
 msgid "Admins"
 msgstr "Administradores"
 
-#: ./sc/social/like/interfaces.py:141
+#: ../interfaces.py:141
 msgid "Application ID"
 msgstr "ID de la aplicación"
 
-#: ./sc/social/like/interfaces.py:87
+#: ../interfaces.py:87
 msgid "Button style"
 msgstr "Estilo de los botones"
 
-#: ./sc/social/like/interfaces.py:63
+#: ../interfaces.py:63
 msgid "Content types"
 msgstr "Tipos de contenido"
 
-#: ./sc/social/like/tiles/twitter.py:26
+#: ../tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr "Recortar y esconder las barras de desplazamiento de la línea de tiempo"
 
-#: ./sc/social/like/tiles/twitter.py:74
+#: ../tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr "Mostrar una línea de tiempo expandida de entre 1 y 20 tweets. Dejar vacío para usar el valor por defecto o para especificar la altura del widget."
 
-#: ./sc/social/like/interfaces.py:98
+#: ../interfaces.py:98
 msgid "Do not track users"
 msgstr "No rastrear usuarios"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: ./sc/social/like/tiles/facebook.py:25
+#: ../tiles/facebook.py:25
 msgid "Events"
 msgstr "Eventos"
 
-#: ./sc/social/like/tiles/facebook.py:35
+#: ../tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr "Página de Facebook"
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr "Tile de Facebook"
 
-#: ./sc/social/like/interfaces.py:152
+#: ../interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Botones de facebook"
 
-#: ./sc/social/like/tiles/facebook.py:53
-#: ./sc/social/like/tiles/twitter.py:54
+#: ../tiles/facebook.py:53
+#: ../tiles/twitter.py:54
 msgid "Height"
 msgstr "Altura"
 
-#: ./sc/social/like/tiles/facebook.py:72
+#: ../tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr "Ocultar la foto del encabezado"
 
-#: ./sc/social/like/tiles/facebook.py:82
+#: ../tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:24
+#: ../tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr "Ocultar el pie de página de la línea de tiempo"
 
-#: ./sc/social/like/tiles/twitter.py:23
+#: ../tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr "Ocultar el encabezado de la línea de tiempo"
 
-#: ./sc/social/like/vocabularies.py:41
+#: ../vocabularies.py:41
 msgid "Like"
 msgstr "Me gusta"
 
-#: ./sc/social/like/tiles/facebook.py:26
+#: ../tiles/facebook.py:26
 msgid "Messages"
 msgstr "Mensajes"
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
+#: ../plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr "Pin it!"
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
+#: ../plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr "Pin it! (abre en una nueva ventana)"
 
-#: ./sc/social/like/interfaces.py:76
+#: ../interfaces.py:76
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ./sc/social/like/vocabularies.py:42
+#: ../vocabularies.py:42
 msgid "Recommend"
 msgstr "Recomendar"
 
-#: ./sc/social/like/tiles/twitter.py:25
+#: ../tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr "Remover los bordes del widget"
 
-#: ./sc/social/like/tiles/twitter.py:27
+#: ../tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr "Remover el color de fondo del widget"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:55
+#: ../tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr "Especificar la altura del widget, sobrescribiendo el valor especificado en la configuración del mismo. Debe ser mayor de 200 píxeles. Nota: este parámetro no aplica si un límite de tweets ha sido especificado."
 
-#: ./sc/social/like/tiles/facebook.py:54
+#: ../tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr "Especificar la altura del widget, sobrescribiendo el valor especificado en la configuración del mismo. Debe ser mayor de 70 píxeles."
 
-#: ./sc/social/like/tiles/facebook.py:42
+#: ../tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Especificar el anchura máxima del widget entre 180 y 520 píxeles. Dejar en blanco si desea ajusta la anchura del widget de forma automática dentro del tile."
 
-#: ./sc/social/like/tiles/twitter.py:43
+#: ../tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Especificar la anchura máxima del widget entre 180 y 520 píxeles. Dejar en blanco si desea ajusta la anchura del widget de forma automática dentro del tile."
 
-#: ./sc/social/like/controlpanel.py:13
+#: ../controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr "Configuración de sc.social.like."
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
-#: ./sc/social/like/vocabularies.py:47
+#: ../plugins/telegram/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ../vocabularies.py:47
 msgid "Share"
 msgstr "Compartir"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr "Enviar por email"
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:12
+#: ../plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr "Compartir en Facebook"
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:6
+#: ../plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr "Compartir en Facebook (abre en una nueva ventana)"
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:9
+#: ../plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr "Compartir en Google+"
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:3
+#: ../plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr "Compartir en Google+ (abre en una nueva ventana)"
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
+#: ../plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr "Compartir en LinkedIn"
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
+#: ../plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr "Compartir en LinkedIn (abre en una nueva ventana)"
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ../plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr "Compartir en Telegram"
 
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "Compartir en WhatsApp"
 
-#: ./sc/social/like/tiles/facebook.py:77
+#: ../interfaces.py:163
+msgid "Show number of likes"
+msgstr ""
+
+#: ../tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr "Mostrar las fotos del perfil de los amigos que  recomienden esto"
 
-#: ./sc/social/like/tiles/facebook.py:87
+#: ../tiles/facebook.py:87
 msgid "Show small header"
 msgstr "Mostrar encabezado pequeño"
 
-#: ./sc/social/like/controlpanel.py:12
-#: ./sc/social/like/profiles/default/controlpanel.xml
+#: ../controlpanel.py:12
+#: ../profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social Like"
 
-#: ./sc/social/like/tiles/facebook.py:36
+#: ../tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr "El URL de la página de Facebook."
 
-#: ./sc/social/like/tiles/facebook.py:24
+#: ../tiles/facebook.py:24
 msgid "Timeline"
 msgstr "Línea de teimpo"
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:9
+#: ../plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr "Tweetear"
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:3
+#: ../plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr "Tweetear (abre en una nueva ventana)"
 
-#: ./sc/social/like/tiles/twitter.py:73
+#: ../tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr "Límite de tweets"
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr "Tile de Twitter"
 
-#: ./sc/social/like/interfaces.py:166
+#: ../interfaces.py:176
 msgid "Twitter nick"
 msgstr "Nombre de usuario en Twitter"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:117
+#: ../interfaces.py:117
 msgid "Verb to display"
 msgstr "Texto a mostrar"
 
-#: ./sc/social/like/tiles/twitter.py:85
+#: ../tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr "Cortesía WAI-ARIA"
 
-#: ./sc/social/like/tiles/twitter.py:36
+#: ../tiles/twitter.py:36
 msgid "Widget ID"
 msgstr "ID del widget"
 
-#: ./sc/social/like/tiles/facebook.py:41
-#: ./sc/social/like/tiles/twitter.py:42
+#: ../tiles/facebook.py:41
+#: ../tiles/twitter.py:42
 msgid "Width"
 msgstr "Ancho"
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ./sc/social/like/interfaces.py:131
+#: ../interfaces.py:131
 #, fuzzy
 msgid "help_admins"
 msgstr "Una lista de los ID de los administradores de esta página, separados por comas, o el ID de una aplicación de Facebook."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ./sc/social/like/interfaces.py:142
+#: ../interfaces.py:142
 msgid "help_appid"
 msgstr "El ID de la aplicación en la plataforma Facebook. Esto es necesario cuando la opción \"No rastrear usuarios\" está habilitada."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ./sc/social/like/interfaces.py:99
+#: ../interfaces.py:99
 msgid "help_do_not_track"
 msgstr "Si está habilitado, el portal no renderizará los widgets avanzados sino simples vínculos a los servicios existentes. Esto limitará la experiencia de usuario y las funcionalidades (como el conteo cuantas veces fue compartido un elemento)  pero respetará la privacidad de los usuarios al no enviar cookies de terceros."
 
 #. Default: "Please select which plugins will be used"
-#: ./sc/social/like/interfaces.py:77
+#: ../interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Seleccione los plugins que desea usar"
 
 #. Default: "Select buttons to be shown"
-#: ./sc/social/like/interfaces.py:153
+#: ../interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Seleccione los botones que serán mostrados"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ./sc/social/like/interfaces.py:64
+#: ../interfaces.py:64
 msgid "help_portal_types"
 msgstr "Seleccione en cuáles tipos de contenido se mostrará el viewlet social."
 
 #. Default: "Choose your button style."
-#: ./sc/social/like/interfaces.py:88
+#: ../interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Seleccione de la lista."
 
+#. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
+#: ../interfaces.py:164
+msgid "help_show_likes"
+msgstr ""
+
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ./sc/social/like/interfaces.py:118
+#: ../interfaces.py:118
 msgid "help_verb_display"
 msgstr "Texto que se mostrará en el botón de Facebook. De momento sólo \"Me gusta\" y \"Recomendar\" están soportados."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ./sc/social/like/interfaces.py:167
+#: ../interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Introduzca su nombre de usuario de Twitter. Ejemplo: simplesconsultoria"
 
-#: ./sc/social/like/vocabularies.py:35
+#: ../vocabularies.py:35
 msgid "horizontal"
 msgstr "Horizontal"
 
-#: ./sc/social/like/vocabularies.py:36
+#: ../vocabularies.py:36
 msgid "vertical"
 msgstr "Vertical"

--- a/sc/social/like/locales/es/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/es/LC_MESSAGES/sc.social.like.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social.like\n"
-"POT-Creation-Date: 2017-03-06 14:08+0000\n"
+"POT-Creation-Date: 2017-03-06 16:27+0000\n"
 "PO-Revision-Date: 2017-02-01 16:38-0200\n"
 "Last-Translator: Héctor Velarde <hector.velarde@gmail.com>\n"
 "Language-Team: Simples Consultoria <products@simplesconsultoria.com.br>\n"
@@ -19,314 +19,314 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr "Una integración sencilla, pero útil, de redes sociales con Plone."
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr "Tile para integrar una página de Facebook."
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr "Tile para integrar una línea de tiempo de Twitter."
 
-#: ../tiles/twitter.py:86
+#: ./sc/social/like/tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr "Un widget de línea de tiempo es una región en una página que puede recibir actualizaciones a medida que nuevos tweets estén disponibles. Cuando se especifica polite, las tecnologías de asistencia notificarán a los usuarios de las actualizaciones, pero no interrumpirán de manera general la tarea actual y las actualizaciones tendrán poca prioridad. Cuando se especifica assertive, las tecnologías de asistencia notificarán inmediatamente al usuario y podrían eliminar la cola de mensajes de las actualizaciones anteriores."
 
-#: ../interfaces.py:130
+#: ./sc/social/like/interfaces.py:130
 msgid "Admins"
 msgstr "Administradores"
 
-#: ../interfaces.py:141
+#: ./sc/social/like/interfaces.py:141
 msgid "Application ID"
 msgstr "ID de la aplicación"
 
-#: ../interfaces.py:87
+#: ./sc/social/like/interfaces.py:87
 msgid "Button style"
 msgstr "Estilo de los botones"
 
-#: ../interfaces.py:63
+#: ./sc/social/like/interfaces.py:63
 msgid "Content types"
 msgstr "Tipos de contenido"
 
-#: ../tiles/twitter.py:26
+#: ./sc/social/like/tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr "Recortar y esconder las barras de desplazamiento de la línea de tiempo"
 
-#: ../tiles/twitter.py:74
+#: ./sc/social/like/tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr "Mostrar una línea de tiempo expandida de entre 1 y 20 tweets. Dejar vacío para usar el valor por defecto o para especificar la altura del widget."
 
-#: ../interfaces.py:98
+#: ./sc/social/like/interfaces.py:98
 msgid "Do not track users"
 msgstr "No rastrear usuarios"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: ../tiles/facebook.py:25
+#: ./sc/social/like/tiles/facebook.py:25
 msgid "Events"
 msgstr "Eventos"
 
-#: ../tiles/facebook.py:35
+#: ./sc/social/like/tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr "Página de Facebook"
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr "Tile de Facebook"
 
-#: ../interfaces.py:152
+#: ./sc/social/like/interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Botones de facebook"
 
-#: ../tiles/facebook.py:53
-#: ../tiles/twitter.py:54
+#: ./sc/social/like/tiles/facebook.py:53
+#: ./sc/social/like/tiles/twitter.py:54
 msgid "Height"
 msgstr "Altura"
 
-#: ../tiles/facebook.py:72
+#: ./sc/social/like/tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr "Ocultar la foto del encabezado"
 
-#: ../tiles/facebook.py:82
+#: ./sc/social/like/tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ../tiles/twitter.py:24
+#: ./sc/social/like/tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr "Ocultar el pie de página de la línea de tiempo"
 
-#: ../tiles/twitter.py:23
+#: ./sc/social/like/tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr "Ocultar el encabezado de la línea de tiempo"
 
-#: ../vocabularies.py:41
+#: ./sc/social/like/vocabularies.py:41
 msgid "Like"
 msgstr "Me gusta"
 
-#: ../tiles/facebook.py:26
+#: ./sc/social/like/tiles/facebook.py:26
 msgid "Messages"
 msgstr "Mensajes"
 
-#: ../plugins/pinterest/templates/link.pt:11
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr "Pin it!"
 
-#: ../plugins/pinterest/templates/link.pt:3
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr "Pin it! (abre en una nueva ventana)"
 
-#: ../interfaces.py:76
+#: ./sc/social/like/interfaces.py:76
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../vocabularies.py:42
+#: ./sc/social/like/vocabularies.py:42
 msgid "Recommend"
 msgstr "Recomendar"
 
-#: ../tiles/twitter.py:25
+#: ./sc/social/like/tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr "Remover los bordes del widget"
 
-#: ../tiles/twitter.py:27
+#: ./sc/social/like/tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr "Remover el color de fondo del widget"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ../tiles/twitter.py:55
+#: ./sc/social/like/tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr "Especificar la altura del widget, sobrescribiendo el valor especificado en la configuración del mismo. Debe ser mayor de 200 píxeles. Nota: este parámetro no aplica si un límite de tweets ha sido especificado."
 
-#: ../tiles/facebook.py:54
+#: ./sc/social/like/tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr "Especificar la altura del widget, sobrescribiendo el valor especificado en la configuración del mismo. Debe ser mayor de 70 píxeles."
 
-#: ../tiles/facebook.py:42
+#: ./sc/social/like/tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Especificar el anchura máxima del widget entre 180 y 520 píxeles. Dejar en blanco si desea ajusta la anchura del widget de forma automática dentro del tile."
 
-#: ../tiles/twitter.py:43
+#: ./sc/social/like/tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Especificar la anchura máxima del widget entre 180 y 520 píxeles. Dejar en blanco si desea ajusta la anchura del widget de forma automática dentro del tile."
 
-#: ../controlpanel.py:13
+#: ./sc/social/like/controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr "Configuración de sc.social.like."
 
-#: ../plugins/telegram/plugin.pt:2
-#: ../plugins/whatsapp/templates/plugin.pt:2
-#: ../vocabularies.py:47
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/vocabularies.py:47
 msgid "Share"
 msgstr "Compartir"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr "Enviar por email"
 
-#: ../plugins/facebook/templates/link.pt:12
+#: ./sc/social/like/plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr "Compartir en Facebook"
 
-#: ../plugins/facebook/templates/link.pt:6
+#: ./sc/social/like/plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr "Compartir en Facebook (abre en una nueva ventana)"
 
-#: ../plugins/gplus/templates/link.pt:9
+#: ./sc/social/like/plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr "Compartir en Google+"
 
-#: ../plugins/gplus/templates/link.pt:3
+#: ./sc/social/like/plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr "Compartir en Google+ (abre en una nueva ventana)"
 
-#: ../plugins/linkedin/templates/link.pt:9
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr "Compartir en LinkedIn"
 
-#: ../plugins/linkedin/templates/link.pt:3
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr "Compartir en LinkedIn (abre en una nueva ventana)"
 
-#: ../plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr "Compartir en Telegram"
 
-#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "Compartir en WhatsApp"
 
-#: ../interfaces.py:163
+#: ./sc/social/like/interfaces.py:163
 msgid "Show number of likes"
 msgstr ""
 
-#: ../tiles/facebook.py:77
+#: ./sc/social/like/tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr "Mostrar las fotos del perfil de los amigos que  recomienden esto"
 
-#: ../tiles/facebook.py:87
+#: ./sc/social/like/tiles/facebook.py:87
 msgid "Show small header"
 msgstr "Mostrar encabezado pequeño"
 
-#: ../controlpanel.py:12
-#: ../profiles/default/controlpanel.xml
+#: ./sc/social/like/controlpanel.py:12
+#: ./sc/social/like/profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social Like"
 
-#: ../tiles/facebook.py:36
+#: ./sc/social/like/tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr "El URL de la página de Facebook."
 
-#: ../tiles/facebook.py:24
+#: ./sc/social/like/tiles/facebook.py:24
 msgid "Timeline"
 msgstr "Línea de teimpo"
 
-#: ../plugins/twitter/templates/link.pt:9
+#: ./sc/social/like/plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr "Tweetear"
 
-#: ../plugins/twitter/templates/link.pt:3
+#: ./sc/social/like/plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr "Tweetear (abre en una nueva ventana)"
 
-#: ../tiles/twitter.py:73
+#: ./sc/social/like/tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr "Límite de tweets"
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr "Tile de Twitter"
 
-#: ../interfaces.py:176
+#: ./sc/social/like/interfaces.py:176
 msgid "Twitter nick"
 msgstr "Nombre de usuario en Twitter"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ../interfaces.py:117
+#: ./sc/social/like/interfaces.py:117
 msgid "Verb to display"
 msgstr "Texto a mostrar"
 
-#: ../tiles/twitter.py:85
+#: ./sc/social/like/tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr "Cortesía WAI-ARIA"
 
-#: ../tiles/twitter.py:36
+#: ./sc/social/like/tiles/twitter.py:36
 msgid "Widget ID"
 msgstr "ID del widget"
 
-#: ../tiles/facebook.py:41
-#: ../tiles/twitter.py:42
+#: ./sc/social/like/tiles/facebook.py:41
+#: ./sc/social/like/tiles/twitter.py:42
 msgid "Width"
 msgstr "Ancho"
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ../interfaces.py:131
+#: ./sc/social/like/interfaces.py:131
 #, fuzzy
 msgid "help_admins"
 msgstr "Una lista de los ID de los administradores de esta página, separados por comas, o el ID de una aplicación de Facebook."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ../interfaces.py:142
+#: ./sc/social/like/interfaces.py:142
 msgid "help_appid"
 msgstr "El ID de la aplicación en la plataforma Facebook. Esto es necesario cuando la opción \"No rastrear usuarios\" está habilitada."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ../interfaces.py:99
+#: ./sc/social/like/interfaces.py:99
 msgid "help_do_not_track"
 msgstr "Si está habilitado, el portal no renderizará los widgets avanzados sino simples vínculos a los servicios existentes. Esto limitará la experiencia de usuario y las funcionalidades (como el conteo cuantas veces fue compartido un elemento)  pero respetará la privacidad de los usuarios al no enviar cookies de terceros."
 
 #. Default: "Please select which plugins will be used"
-#: ../interfaces.py:77
+#: ./sc/social/like/interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Seleccione los plugins que desea usar"
 
 #. Default: "Select buttons to be shown"
-#: ../interfaces.py:153
+#: ./sc/social/like/interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Seleccione los botones que serán mostrados"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ../interfaces.py:64
+#: ./sc/social/like/interfaces.py:64
 msgid "help_portal_types"
 msgstr "Seleccione en cuáles tipos de contenido se mostrará el viewlet social."
 
 #. Default: "Choose your button style."
-#: ../interfaces.py:88
+#: ./sc/social/like/interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Seleccione de la lista."
 
 #. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
-#: ../interfaces.py:164
+#: ./sc/social/like/interfaces.py:164
 msgid "help_show_likes"
 msgstr ""
 
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ../interfaces.py:118
+#: ./sc/social/like/interfaces.py:118
 msgid "help_verb_display"
 msgstr "Texto que se mostrará en el botón de Facebook. De momento sólo \"Me gusta\" y \"Recomendar\" están soportados."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ../interfaces.py:177
+#: ./sc/social/like/interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Introduzca su nombre de usuario de Twitter. Ejemplo: simplesconsultoria"
 
-#: ../vocabularies.py:35
+#: ./sc/social/like/vocabularies.py:35
 msgid "horizontal"
 msgstr "Horizontal"
 
-#: ../vocabularies.py:36
+#: ./sc/social/like/vocabularies.py:36
 msgid "vertical"
 msgstr "Vertical"

--- a/sc/social/like/locales/eu/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/eu/LC_MESSAGES/sc.social.like.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social.like\n"
-"POT-Creation-Date: 2017-03-06 14:08+0000\n"
+"POT-Creation-Date: 2017-03-06 16:27+0000\n"
 "PO-Revision-Date: 2011-12-12 13:30+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: es <es@li.org>\n"
@@ -15,315 +15,315 @@ msgstr ""
 "Domain: DOMAIN\n"
 "X-Poedit-Language: Spanish\n"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr ""
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr ""
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr ""
 
-#: ../tiles/twitter.py:86
+#: ./sc/social/like/tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr ""
 
-#: ../interfaces.py:130
+#: ./sc/social/like/interfaces.py:130
 msgid "Admins"
 msgstr "Kudeatzaileak"
 
-#: ../interfaces.py:141
+#: ./sc/social/like/interfaces.py:141
 msgid "Application ID"
 msgstr ""
 
-#: ../interfaces.py:87
+#: ./sc/social/like/interfaces.py:87
 msgid "Button style"
 msgstr "Botoien ixuria"
 
-#: ../interfaces.py:63
+#: ./sc/social/like/interfaces.py:63
 msgid "Content types"
 msgstr "Elementu-motak"
 
-#: ../tiles/twitter.py:26
+#: ./sc/social/like/tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ../tiles/twitter.py:74
+#: ./sc/social/like/tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ../interfaces.py:98
+#: ./sc/social/like/interfaces.py:98
 msgid "Do not track users"
 msgstr ""
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ../tiles/facebook.py:25
+#: ./sc/social/like/tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ../tiles/facebook.py:35
+#: ./sc/social/like/tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ../interfaces.py:152
+#: ./sc/social/like/interfaces.py:152
 msgid "Facebook buttons"
 msgstr ""
 
-#: ../tiles/facebook.py:53
-#: ../tiles/twitter.py:54
+#: ./sc/social/like/tiles/facebook.py:53
+#: ./sc/social/like/tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ../tiles/facebook.py:72
+#: ./sc/social/like/tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ../tiles/facebook.py:82
+#: ./sc/social/like/tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ../tiles/twitter.py:24
+#: ./sc/social/like/tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ../tiles/twitter.py:23
+#: ./sc/social/like/tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ../vocabularies.py:41
+#: ./sc/social/like/vocabularies.py:41
 msgid "Like"
 msgstr "Atsegin dut!"
 
-#: ../tiles/facebook.py:26
+#: ./sc/social/like/tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ../plugins/pinterest/templates/link.pt:11
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr ""
 
-#: ../plugins/pinterest/templates/link.pt:3
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr ""
 
-#: ../interfaces.py:76
+#: ./sc/social/like/interfaces.py:76
 msgid "Plugins"
 msgstr ""
 
-#: ../vocabularies.py:42
+#: ./sc/social/like/vocabularies.py:42
 msgid "Recommend"
 msgstr "Gomendatu!"
 
-#: ../tiles/twitter.py:25
+#: ./sc/social/like/tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr ""
 
-#: ../tiles/twitter.py:27
+#: ./sc/social/like/tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr ""
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ../tiles/twitter.py:55
+#: ./sc/social/like/tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr ""
 
-#: ../tiles/facebook.py:54
+#: ./sc/social/like/tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr ""
 
-#: ../tiles/facebook.py:42
+#: ./sc/social/like/tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ../tiles/twitter.py:43
+#: ./sc/social/like/tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ../controlpanel.py:13
+#: ./sc/social/like/controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ../plugins/telegram/plugin.pt:2
-#: ../plugins/whatsapp/templates/plugin.pt:2
-#: ../vocabularies.py:47
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/vocabularies.py:47
 msgid "Share"
 msgstr ""
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr ""
 
-#: ../plugins/facebook/templates/link.pt:12
+#: ./sc/social/like/plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr ""
 
-#: ../plugins/facebook/templates/link.pt:6
+#: ./sc/social/like/plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr ""
 
-#: ../plugins/gplus/templates/link.pt:9
+#: ./sc/social/like/plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr ""
 
-#: ../plugins/gplus/templates/link.pt:3
+#: ./sc/social/like/plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr ""
 
-#: ../plugins/linkedin/templates/link.pt:9
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr ""
 
-#: ../plugins/linkedin/templates/link.pt:3
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr ""
 
-#: ../plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr ""
 
-#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr ""
 
-#: ../interfaces.py:163
+#: ./sc/social/like/interfaces.py:163
 msgid "Show number of likes"
 msgstr ""
 
-#: ../tiles/facebook.py:77
+#: ./sc/social/like/tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr ""
 
-#: ../tiles/facebook.py:87
+#: ./sc/social/like/tiles/facebook.py:87
 msgid "Show small header"
 msgstr ""
 
-#: ../controlpanel.py:12
-#: ../profiles/default/controlpanel.xml
+#: ./sc/social/like/controlpanel.py:12
+#: ./sc/social/like/profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: \"Atsegin dut\" akzioak"
 
-#: ../tiles/facebook.py:36
+#: ./sc/social/like/tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr ""
 
-#: ../tiles/facebook.py:24
+#: ./sc/social/like/tiles/facebook.py:24
 msgid "Timeline"
 msgstr ""
 
-#: ../plugins/twitter/templates/link.pt:9
+#: ./sc/social/like/plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr ""
 
-#: ../plugins/twitter/templates/link.pt:3
+#: ./sc/social/like/plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr ""
 
-#: ../tiles/twitter.py:73
+#: ./sc/social/like/tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr ""
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr ""
 
-#: ../interfaces.py:176
+#: ./sc/social/like/interfaces.py:176
 msgid "Twitter nick"
 msgstr "Twitter izena"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ../interfaces.py:117
+#: ./sc/social/like/interfaces.py:117
 msgid "Verb to display"
 msgstr "Erakutsiko den testua"
 
-#: ../tiles/twitter.py:85
+#: ./sc/social/like/tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr ""
 
-#: ../tiles/twitter.py:36
+#: ./sc/social/like/tiles/twitter.py:36
 msgid "Widget ID"
 msgstr ""
 
-#: ../tiles/facebook.py:41
-#: ../tiles/twitter.py:42
+#: ./sc/social/like/tiles/facebook.py:41
+#: ./sc/social/like/tiles/twitter.py:42
 msgid "Width"
 msgstr ""
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ../interfaces.py:131
+#: ./sc/social/like/interfaces.py:131
 #, fuzzy
 msgid "help_admins"
 msgstr "Facebook kontuaren kudeatzaileen Facebook IDak. Banatu komarekin bat baino gehiagoa badaude."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ../interfaces.py:142
+#: ./sc/social/like/interfaces.py:142
 msgid "help_appid"
 msgstr ""
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ../interfaces.py:99
+#: ./sc/social/like/interfaces.py:99
 msgid "help_do_not_track"
 msgstr ""
 
 #. Default: "Please select which plugins will be used"
-#: ../interfaces.py:77
+#: ./sc/social/like/interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr ""
 
 #. Default: "Select buttons to be shown"
-#: ../interfaces.py:153
+#: ./sc/social/like/interfaces.py:153
 msgid "help_fbbuttons"
 msgstr ""
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ../interfaces.py:64
+#: ./sc/social/like/interfaces.py:64
 msgid "help_portal_types"
 msgstr "Aukeratu zein elementutan agertuko diren loturak"
 
 #. Default: "Choose your button style."
-#: ../interfaces.py:88
+#: ./sc/social/like/interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Aukeratu botoiaren itxura"
 
 #. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
-#: ../interfaces.py:164
+#: ./sc/social/like/interfaces.py:164
 msgid "help_show_likes"
 msgstr ""
 
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ../interfaces.py:118
+#: ./sc/social/like/interfaces.py:118
 #, fuzzy
 msgid "help_verb_display"
 msgstr "Zein hitz agertuko den Facebook botoian. Momentuz 'Atsegin dut' eta 'Gomendatu' bakarrik erabili daitezke."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ../interfaces.py:177
+#: ./sc/social/like/interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Idatzi Twitterreko zuren izena. adb. simplesconsultoria"
 
-#: ../vocabularies.py:35
+#: ./sc/social/like/vocabularies.py:35
 msgid "horizontal"
 msgstr "Horizontala"
 
-#: ../vocabularies.py:36
+#: ./sc/social/like/vocabularies.py:36
 msgid "vertical"
 msgstr "Bertikala"

--- a/sc/social/like/locales/eu/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/eu/LC_MESSAGES/sc.social.like.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social.like\n"
-"POT-Creation-Date: 2017-02-01 18:40+0000\n"
+"POT-Creation-Date: 2017-03-06 14:08+0000\n"
 "PO-Revision-Date: 2011-12-12 13:30+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: es <es@li.org>\n"
@@ -15,306 +15,315 @@ msgstr ""
 "Domain: DOMAIN\n"
 "X-Poedit-Language: Spanish\n"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:86
+#: ../tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:130
+#: ../interfaces.py:130
 msgid "Admins"
 msgstr "Kudeatzaileak"
 
-#: ./sc/social/like/interfaces.py:141
+#: ../interfaces.py:141
 msgid "Application ID"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:87
+#: ../interfaces.py:87
 msgid "Button style"
 msgstr "Botoien ixuria"
 
-#: ./sc/social/like/interfaces.py:63
+#: ../interfaces.py:63
 msgid "Content types"
 msgstr "Elementu-motak"
 
-#: ./sc/social/like/tiles/twitter.py:26
+#: ../tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:74
+#: ../tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:98
+#: ../interfaces.py:98
 msgid "Do not track users"
 msgstr ""
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:25
+#: ../tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:35
+#: ../tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:152
+#: ../interfaces.py:152
 msgid "Facebook buttons"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:53
-#: ./sc/social/like/tiles/twitter.py:54
+#: ../tiles/facebook.py:53
+#: ../tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:72
+#: ../tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:82
+#: ../tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:24
+#: ../tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:23
+#: ../tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:41
+#: ../vocabularies.py:41
 msgid "Like"
 msgstr "Atsegin dut!"
 
-#: ./sc/social/like/tiles/facebook.py:26
+#: ../tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
+#: ../plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
+#: ../plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:76
+#: ../interfaces.py:76
 msgid "Plugins"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:42
+#: ../vocabularies.py:42
 msgid "Recommend"
 msgstr "Gomendatu!"
 
-#: ./sc/social/like/tiles/twitter.py:25
+#: ../tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:27
+#: ../tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr ""
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:55
+#: ../tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:54
+#: ../tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:42
+#: ../tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:43
+#: ../tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ./sc/social/like/controlpanel.py:13
+#: ../controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
-#: ./sc/social/like/vocabularies.py:47
+#: ../plugins/telegram/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ../vocabularies.py:47
 msgid "Share"
 msgstr ""
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr ""
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:12
+#: ../plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr ""
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:6
+#: ../plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:9
+#: ../plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr ""
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:3
+#: ../plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
+#: ../plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr ""
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
+#: ../plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ../plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr ""
 
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:77
+#: ../interfaces.py:163
+msgid "Show number of likes"
+msgstr ""
+
+#: ../tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:87
+#: ../tiles/facebook.py:87
 msgid "Show small header"
 msgstr ""
 
-#: ./sc/social/like/controlpanel.py:12
-#: ./sc/social/like/profiles/default/controlpanel.xml
+#: ../controlpanel.py:12
+#: ../profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: \"Atsegin dut\" akzioak"
 
-#: ./sc/social/like/tiles/facebook.py:36
+#: ../tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:24
+#: ../tiles/facebook.py:24
 msgid "Timeline"
 msgstr ""
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:9
+#: ../plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr ""
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:3
+#: ../plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:73
+#: ../tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:166
+#: ../interfaces.py:176
 msgid "Twitter nick"
 msgstr "Twitter izena"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:117
+#: ../interfaces.py:117
 msgid "Verb to display"
 msgstr "Erakutsiko den testua"
 
-#: ./sc/social/like/tiles/twitter.py:85
+#: ../tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:36
+#: ../tiles/twitter.py:36
 msgid "Widget ID"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:41
-#: ./sc/social/like/tiles/twitter.py:42
+#: ../tiles/facebook.py:41
+#: ../tiles/twitter.py:42
 msgid "Width"
 msgstr ""
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ./sc/social/like/interfaces.py:131
+#: ../interfaces.py:131
 #, fuzzy
 msgid "help_admins"
 msgstr "Facebook kontuaren kudeatzaileen Facebook IDak. Banatu komarekin bat baino gehiagoa badaude."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ./sc/social/like/interfaces.py:142
+#: ../interfaces.py:142
 msgid "help_appid"
 msgstr ""
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ./sc/social/like/interfaces.py:99
+#: ../interfaces.py:99
 msgid "help_do_not_track"
 msgstr ""
 
 #. Default: "Please select which plugins will be used"
-#: ./sc/social/like/interfaces.py:77
+#: ../interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr ""
 
 #. Default: "Select buttons to be shown"
-#: ./sc/social/like/interfaces.py:153
+#: ../interfaces.py:153
 msgid "help_fbbuttons"
 msgstr ""
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ./sc/social/like/interfaces.py:64
+#: ../interfaces.py:64
 msgid "help_portal_types"
 msgstr "Aukeratu zein elementutan agertuko diren loturak"
 
 #. Default: "Choose your button style."
-#: ./sc/social/like/interfaces.py:88
+#: ../interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Aukeratu botoiaren itxura"
 
+#. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
+#: ../interfaces.py:164
+msgid "help_show_likes"
+msgstr ""
+
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ./sc/social/like/interfaces.py:118
+#: ../interfaces.py:118
 #, fuzzy
 msgid "help_verb_display"
 msgstr "Zein hitz agertuko den Facebook botoian. Momentuz 'Atsegin dut' eta 'Gomendatu' bakarrik erabili daitezke."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ./sc/social/like/interfaces.py:167
+#: ../interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Idatzi Twitterreko zuren izena. adb. simplesconsultoria"
 
-#: ./sc/social/like/vocabularies.py:35
+#: ../vocabularies.py:35
 msgid "horizontal"
 msgstr "Horizontala"
 
-#: ./sc/social/like/vocabularies.py:36
+#: ../vocabularies.py:36
 msgid "vertical"
 msgstr "Bertikala"

--- a/sc/social/like/locales/it/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/it/LC_MESSAGES/sc.social.like.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-01 18:40+0000\n"
+"POT-Creation-Date: 2017-03-06 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Luca Fabbri <keul@redturtle.it>\n"
 "Language-Team: RedTurtle Technology <sviluppoplone@redturtle.it>\n"
@@ -18,308 +18,317 @@ msgstr ""
 "Domain: sc.social.like\n"
 "X-Is-Fallback-For: it-ch it-it\n"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr "Una semplice ma funzionale integrazione tra Plone e i social network"
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:86
+#: ../tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:130
+#: ../interfaces.py:130
 msgid "Admins"
 msgstr "Amministratori"
 
-#: ./sc/social/like/interfaces.py:141
+#: ../interfaces.py:141
 msgid "Application ID"
 msgstr "ID applicazione"
 
-#: ./sc/social/like/interfaces.py:87
+#: ../interfaces.py:87
 msgid "Button style"
 msgstr "Stile del bottone"
 
-#: ./sc/social/like/interfaces.py:63
+#: ../interfaces.py:63
 msgid "Content types"
 msgstr "Tipi di contenuto"
 
-#: ./sc/social/like/tiles/twitter.py:26
+#: ../tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:74
+#: ../tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:98
+#: ../interfaces.py:98
 msgid "Do not track users"
 msgstr "Non tracciare gli utenti"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:25
+#: ../tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:35
+#: ../tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:152
+#: ../interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Bottoni Facebook"
 
-#: ./sc/social/like/tiles/facebook.py:53
-#: ./sc/social/like/tiles/twitter.py:54
+#: ../tiles/facebook.py:53
+#: ../tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:72
+#: ../tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:82
+#: ../tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:24
+#: ../tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:23
+#: ../tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:41
+#: ../vocabularies.py:41
 msgid "Like"
 msgstr "Mi piace"
 
-#: ./sc/social/like/tiles/facebook.py:26
+#: ../tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
+#: ../plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
+#: ../plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr "Pin it! (apre in una nuova finestra)"
 
-#: ./sc/social/like/interfaces.py:76
+#: ../interfaces.py:76
 msgid "Plugins"
 msgstr "Plugin"
 
-#: ./sc/social/like/vocabularies.py:42
+#: ../vocabularies.py:42
 msgid "Recommend"
 msgstr "Consigliato"
 
-#: ./sc/social/like/tiles/twitter.py:25
+#: ../tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:27
+#: ../tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr ""
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:55
+#: ../tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:54
+#: ../tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:42
+#: ../tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:43
+#: ../tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ./sc/social/like/controlpanel.py:13
+#: ../controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
-#: ./sc/social/like/vocabularies.py:47
+#: ../plugins/telegram/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ../vocabularies.py:47
 msgid "Share"
 msgstr "Condividi"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr ""
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:12
+#: ../plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr "Condividi su Facebook"
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:6
+#: ../plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr "Condividi su Facebook (apre in una nuova finestra)"
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:9
+#: ../plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr "Condividi su Google+"
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:3
+#: ../plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr "Condividi su Google+ (apre in una nuova finestra)"
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
+#: ../plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr "Condividi su Linkedin"
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
+#: ../plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr "Condividi su Linkedin (apre in una nuova finestra)"
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ../plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr ""
 
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "Condividi in WhatsApp"
 
-#: ./sc/social/like/tiles/facebook.py:77
+#: ../interfaces.py:163
+msgid "Show number of likes"
+msgstr ""
+
+#: ../tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:87
+#: ../tiles/facebook.py:87
 msgid "Show small header"
 msgstr ""
 
-#: ./sc/social/like/controlpanel.py:12
-#: ./sc/social/like/profiles/default/controlpanel.xml
+#: ../controlpanel.py:12
+#: ../profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr ""
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: azioni di like"
 
-#: ./sc/social/like/tiles/facebook.py:36
+#: ../tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:24
+#: ../tiles/facebook.py:24
 msgid "Timeline"
 msgstr ""
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:9
+#: ../plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr ""
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:3
+#: ../plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr "Tweet it! (apre in una nuova finestra)"
 
-#: ./sc/social/like/tiles/twitter.py:73
+#: ../tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:166
+#: ../interfaces.py:176
 msgid "Twitter nick"
 msgstr "Nickname Twitter"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:117
+#: ../interfaces.py:117
 msgid "Verb to display"
 msgstr "Verbo da visualizzare"
 
-#: ./sc/social/like/tiles/twitter.py:85
+#: ../tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:36
+#: ../tiles/twitter.py:36
 msgid "Widget ID"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:41
-#: ./sc/social/like/tiles/twitter.py:42
+#: ../tiles/facebook.py:41
+#: ../tiles/twitter.py:42
 msgid "Width"
 msgstr ""
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ./sc/social/like/interfaces.py:131
+#: ../interfaces.py:131
 msgid "help_admins"
 msgstr "Una lista separata da virgole di ID Facebook di amministratori della pagina"
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ./sc/social/like/interfaces.py:142
+#: ../interfaces.py:142
 msgid "help_appid"
 msgstr ""
 "L'ID di un'applicazione Facebook.\n"
 "Questa informazione è richiesta quando l'impostazione \"Non tracciare gli utenti\" è abilitata."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ./sc/social/like/interfaces.py:99
+#: ../interfaces.py:99
 msgid "help_do_not_track"
 msgstr ""
 "Se abilitata, il sito not fornirà i componenti di condivisione avanzati ma saranno usati dei semplici link.\n"
 "Questo limita l'esperienza utente e le funzionalità (come il conteggio delle condivisioni) ma aumenta la privacy degli utenti: nessun cookie di terze party sarà inviato agli utenti."
 
 #. Default: "Please select which plugins will be used"
-#: ./sc/social/like/interfaces.py:77
+#: ../interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Prego selezionare quali plugin verranno usati"
 
 #. Default: "Select buttons to be shown"
-#: ./sc/social/like/interfaces.py:153
+#: ../interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Seleziona i bottoni da visualizzare"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ./sc/social/like/interfaces.py:64
+#: ../interfaces.py:64
 msgid "help_portal_types"
 msgstr "Prego selezionare su quali tipi di contenuto la viewlet verrà applicata"
 
 #. Default: "Choose your button style."
-#: ./sc/social/like/interfaces.py:88
+#: ../interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Seleziona lo stile del bottone"
 
+#. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
+#: ../interfaces.py:164
+msgid "help_show_likes"
+msgstr ""
+
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ./sc/social/like/interfaces.py:118
+#: ../interfaces.py:118
 msgid "help_verb_display"
 msgstr "Il verbo da visualizzare nel bottone di Facebook. Al momento solo \"Mi piace\" e \"Consigliato\" sono supportati."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ./sc/social/like/interfaces.py:167
+#: ../interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Inserisci il tuo nickname Twitter, per esempio \"simplesconsultoria\""
 
-#: ./sc/social/like/vocabularies.py:35
+#: ../vocabularies.py:35
 msgid "horizontal"
 msgstr "orizzonatale"
 
-#: ./sc/social/like/vocabularies.py:36
+#: ../vocabularies.py:36
 msgid "vertical"
 msgstr "verticale"

--- a/sc/social/like/locales/it/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/it/LC_MESSAGES/sc.social.like.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-06 14:08+0000\n"
+"POT-Creation-Date: 2017-03-06 16:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Luca Fabbri <keul@redturtle.it>\n"
 "Language-Team: RedTurtle Technology <sviluppoplone@redturtle.it>\n"
@@ -18,317 +18,317 @@ msgstr ""
 "Domain: sc.social.like\n"
 "X-Is-Fallback-For: it-ch it-it\n"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr "Una semplice ma funzionale integrazione tra Plone e i social network"
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr ""
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr ""
 
-#: ../tiles/twitter.py:86
+#: ./sc/social/like/tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr ""
 
-#: ../interfaces.py:130
+#: ./sc/social/like/interfaces.py:130
 msgid "Admins"
 msgstr "Amministratori"
 
-#: ../interfaces.py:141
+#: ./sc/social/like/interfaces.py:141
 msgid "Application ID"
 msgstr "ID applicazione"
 
-#: ../interfaces.py:87
+#: ./sc/social/like/interfaces.py:87
 msgid "Button style"
 msgstr "Stile del bottone"
 
-#: ../interfaces.py:63
+#: ./sc/social/like/interfaces.py:63
 msgid "Content types"
 msgstr "Tipi di contenuto"
 
-#: ../tiles/twitter.py:26
+#: ./sc/social/like/tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ../tiles/twitter.py:74
+#: ./sc/social/like/tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ../interfaces.py:98
+#: ./sc/social/like/interfaces.py:98
 msgid "Do not track users"
 msgstr "Non tracciare gli utenti"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ../tiles/facebook.py:25
+#: ./sc/social/like/tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ../tiles/facebook.py:35
+#: ./sc/social/like/tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ../interfaces.py:152
+#: ./sc/social/like/interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Bottoni Facebook"
 
-#: ../tiles/facebook.py:53
-#: ../tiles/twitter.py:54
+#: ./sc/social/like/tiles/facebook.py:53
+#: ./sc/social/like/tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ../tiles/facebook.py:72
+#: ./sc/social/like/tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ../tiles/facebook.py:82
+#: ./sc/social/like/tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ../tiles/twitter.py:24
+#: ./sc/social/like/tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ../tiles/twitter.py:23
+#: ./sc/social/like/tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ../vocabularies.py:41
+#: ./sc/social/like/vocabularies.py:41
 msgid "Like"
 msgstr "Mi piace"
 
-#: ../tiles/facebook.py:26
+#: ./sc/social/like/tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ../plugins/pinterest/templates/link.pt:11
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr ""
 
-#: ../plugins/pinterest/templates/link.pt:3
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr "Pin it! (apre in una nuova finestra)"
 
-#: ../interfaces.py:76
+#: ./sc/social/like/interfaces.py:76
 msgid "Plugins"
 msgstr "Plugin"
 
-#: ../vocabularies.py:42
+#: ./sc/social/like/vocabularies.py:42
 msgid "Recommend"
 msgstr "Consigliato"
 
-#: ../tiles/twitter.py:25
+#: ./sc/social/like/tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr ""
 
-#: ../tiles/twitter.py:27
+#: ./sc/social/like/tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr ""
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ../tiles/twitter.py:55
+#: ./sc/social/like/tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr ""
 
-#: ../tiles/facebook.py:54
+#: ./sc/social/like/tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr ""
 
-#: ../tiles/facebook.py:42
+#: ./sc/social/like/tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ../tiles/twitter.py:43
+#: ./sc/social/like/tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ../controlpanel.py:13
+#: ./sc/social/like/controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ../plugins/telegram/plugin.pt:2
-#: ../plugins/whatsapp/templates/plugin.pt:2
-#: ../vocabularies.py:47
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/vocabularies.py:47
 msgid "Share"
 msgstr "Condividi"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr ""
 
-#: ../plugins/facebook/templates/link.pt:12
+#: ./sc/social/like/plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr "Condividi su Facebook"
 
-#: ../plugins/facebook/templates/link.pt:6
+#: ./sc/social/like/plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr "Condividi su Facebook (apre in una nuova finestra)"
 
-#: ../plugins/gplus/templates/link.pt:9
+#: ./sc/social/like/plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr "Condividi su Google+"
 
-#: ../plugins/gplus/templates/link.pt:3
+#: ./sc/social/like/plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr "Condividi su Google+ (apre in una nuova finestra)"
 
-#: ../plugins/linkedin/templates/link.pt:9
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr "Condividi su Linkedin"
 
-#: ../plugins/linkedin/templates/link.pt:3
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr "Condividi su Linkedin (apre in una nuova finestra)"
 
-#: ../plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr ""
 
-#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "Condividi in WhatsApp"
 
-#: ../interfaces.py:163
+#: ./sc/social/like/interfaces.py:163
 msgid "Show number of likes"
 msgstr ""
 
-#: ../tiles/facebook.py:77
+#: ./sc/social/like/tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr ""
 
-#: ../tiles/facebook.py:87
+#: ./sc/social/like/tiles/facebook.py:87
 msgid "Show small header"
 msgstr ""
 
-#: ../controlpanel.py:12
-#: ../profiles/default/controlpanel.xml
+#: ./sc/social/like/controlpanel.py:12
+#: ./sc/social/like/profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr ""
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: azioni di like"
 
-#: ../tiles/facebook.py:36
+#: ./sc/social/like/tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr ""
 
-#: ../tiles/facebook.py:24
+#: ./sc/social/like/tiles/facebook.py:24
 msgid "Timeline"
 msgstr ""
 
-#: ../plugins/twitter/templates/link.pt:9
+#: ./sc/social/like/plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr ""
 
-#: ../plugins/twitter/templates/link.pt:3
+#: ./sc/social/like/plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr "Tweet it! (apre in una nuova finestra)"
 
-#: ../tiles/twitter.py:73
+#: ./sc/social/like/tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr ""
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr ""
 
-#: ../interfaces.py:176
+#: ./sc/social/like/interfaces.py:176
 msgid "Twitter nick"
 msgstr "Nickname Twitter"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ../interfaces.py:117
+#: ./sc/social/like/interfaces.py:117
 msgid "Verb to display"
 msgstr "Verbo da visualizzare"
 
-#: ../tiles/twitter.py:85
+#: ./sc/social/like/tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr ""
 
-#: ../tiles/twitter.py:36
+#: ./sc/social/like/tiles/twitter.py:36
 msgid "Widget ID"
 msgstr ""
 
-#: ../tiles/facebook.py:41
-#: ../tiles/twitter.py:42
+#: ./sc/social/like/tiles/facebook.py:41
+#: ./sc/social/like/tiles/twitter.py:42
 msgid "Width"
 msgstr ""
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ../interfaces.py:131
+#: ./sc/social/like/interfaces.py:131
 msgid "help_admins"
 msgstr "Una lista separata da virgole di ID Facebook di amministratori della pagina"
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ../interfaces.py:142
+#: ./sc/social/like/interfaces.py:142
 msgid "help_appid"
 msgstr ""
 "L'ID di un'applicazione Facebook.\n"
 "Questa informazione è richiesta quando l'impostazione \"Non tracciare gli utenti\" è abilitata."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ../interfaces.py:99
+#: ./sc/social/like/interfaces.py:99
 msgid "help_do_not_track"
 msgstr ""
 "Se abilitata, il sito not fornirà i componenti di condivisione avanzati ma saranno usati dei semplici link.\n"
 "Questo limita l'esperienza utente e le funzionalità (come il conteggio delle condivisioni) ma aumenta la privacy degli utenti: nessun cookie di terze party sarà inviato agli utenti."
 
 #. Default: "Please select which plugins will be used"
-#: ../interfaces.py:77
+#: ./sc/social/like/interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Prego selezionare quali plugin verranno usati"
 
 #. Default: "Select buttons to be shown"
-#: ../interfaces.py:153
+#: ./sc/social/like/interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Seleziona i bottoni da visualizzare"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ../interfaces.py:64
+#: ./sc/social/like/interfaces.py:64
 msgid "help_portal_types"
 msgstr "Prego selezionare su quali tipi di contenuto la viewlet verrà applicata"
 
 #. Default: "Choose your button style."
-#: ../interfaces.py:88
+#: ./sc/social/like/interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Seleziona lo stile del bottone"
 
 #. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
-#: ../interfaces.py:164
+#: ./sc/social/like/interfaces.py:164
 msgid "help_show_likes"
 msgstr ""
 
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ../interfaces.py:118
+#: ./sc/social/like/interfaces.py:118
 msgid "help_verb_display"
 msgstr "Il verbo da visualizzare nel bottone di Facebook. Al momento solo \"Mi piace\" e \"Consigliato\" sono supportati."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ../interfaces.py:177
+#: ./sc/social/like/interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Inserisci il tuo nickname Twitter, per esempio \"simplesconsultoria\""
 
-#: ../vocabularies.py:35
+#: ./sc/social/like/vocabularies.py:35
 msgid "horizontal"
 msgstr "orizzonatale"
 
-#: ../vocabularies.py:36
+#: ./sc/social/like/vocabularies.py:36
 msgid "vertical"
 msgstr "verticale"

--- a/sc/social/like/locales/nl/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/nl/LC_MESSAGES/sc.social.like.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social 2.2\n"
-"POT-Creation-Date: 2017-03-06 14:08+0000\n"
+"POT-Creation-Date: 2017-03-06 16:27+0000\n"
 "PO-Revision-Date: 2015-05-29 09:50 +0002\n"
 "Last-Translator: Fred van Dijk <f.van.dijk@zestsoftware.nl>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,313 +16,313 @@ msgstr ""
 "Language: nl\n"
 "X-Is-Fallback-For: nl-be nl-nl\n"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr "Een eenvoudige maar bruikbare Social Media integratie voor Plone"
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr "Een tegel voor een Facebookpagina"
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr "Een tegel voor een Twitter-tijdlijn"
 
-#: ../tiles/twitter.py:86
+#: ./sc/social/like/tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr "Eem tijdlijn-wdiget is een live gedeelte op de webpagina waar tweets bijgewerkt worden zodra ze beschikbaar zijn. "
 
-#: ../interfaces.py:130
+#: ./sc/social/like/interfaces.py:130
 msgid "Admins"
 msgstr "Beheerders"
 
-#: ../interfaces.py:141
+#: ./sc/social/like/interfaces.py:141
 msgid "Application ID"
 msgstr "App ID"
 
-#: ../interfaces.py:87
+#: ./sc/social/like/interfaces.py:87
 msgid "Button style"
 msgstr "Knopstijl"
 
-#: ../interfaces.py:63
+#: ./sc/social/like/interfaces.py:63
 msgid "Content types"
 msgstr "Contenttypes"
 
-#: ../tiles/twitter.py:26
+#: ./sc/social/like/tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
-msgstr ""
+msgstr "Snij af en verberg de scrollbalk in de hoofd tijdlijn"
 
-#: ../tiles/twitter.py:74
+#: ./sc/social/like/tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
-msgstr ""
+msgstr "Toon een uitgebreide tijdlijn van 1 tot 20 tweets. Laat leeg om de standaardweergave te gebruiken of om de hoogte van het widget in te kunnen stellen."
 
-#: ../interfaces.py:98
+#: ./sc/social/like/interfaces.py:98
 msgid "Do not track users"
 msgstr "Volg geen gebruikers (tracking)"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Email"
-msgstr ""
+msgstr "E-mail"
 
-#: ../tiles/facebook.py:25
+#: ./sc/social/like/tiles/facebook.py:25
 msgid "Events"
-msgstr ""
+msgstr "Events"
 
-#: ../tiles/facebook.py:35
+#: ./sc/social/like/tiles/facebook.py:35
 msgid "Facebook Page"
-msgstr ""
+msgstr "Facebookpagina"
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "Facebook Tile"
-msgstr ""
+msgstr "Facebooktegel"
 
-#: ../interfaces.py:152
+#: ./sc/social/like/interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Facebook knoppen"
 
-#: ../tiles/facebook.py:53
-#: ../tiles/twitter.py:54
+#: ./sc/social/like/tiles/facebook.py:53
+#: ./sc/social/like/tiles/twitter.py:54
 msgid "Height"
-msgstr ""
+msgstr "Hoogte"
 
-#: ../tiles/facebook.py:72
+#: ./sc/social/like/tiles/facebook.py:72
 msgid "Hide cover photo in the header"
-msgstr ""
+msgstr "Verberg foto in de header."
 
-#: ../tiles/facebook.py:82
+#: ./sc/social/like/tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
-msgstr ""
+msgstr "Verberg de maatwerk 'call to action'-knop (indien beschikbaar)"
 
-#: ../tiles/twitter.py:24
+#: ./sc/social/like/tiles/twitter.py:24
 msgid "Hide the timeline footer"
-msgstr ""
+msgstr "Verberg de footer van de tijdlijn"
 
-#: ../tiles/twitter.py:23
+#: ./sc/social/like/tiles/twitter.py:23
 msgid "Hide the timeline header"
-msgstr ""
+msgstr "Verberg de header van de tijdlijn"
 
-#: ../vocabularies.py:41
+#: ./sc/social/like/vocabularies.py:41
 msgid "Like"
 msgstr "Vind ik leuk (Like)"
 
-#: ../tiles/facebook.py:26
+#: ./sc/social/like/tiles/facebook.py:26
 msgid "Messages"
-msgstr ""
+msgstr "Berichten"
 
-#: ../plugins/pinterest/templates/link.pt:11
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr "Pin vast!"
 
-#: ../plugins/pinterest/templates/link.pt:3
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr "Pin vast! (open in nieuw venster)"
 
-#: ../interfaces.py:76
+#: ./sc/social/like/interfaces.py:76
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../vocabularies.py:42
+#: ./sc/social/like/vocabularies.py:42
 msgid "Recommend"
 msgstr "Aanbevelen"
 
-#: ../tiles/twitter.py:25
+#: ./sc/social/like/tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr "Verwijder alle randen binnen het widget"
 
-#: ../tiles/twitter.py:27
+#: ./sc/social/like/tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr "Verwijder de achtergrondkleur van het widget"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr "De-installeer Social: Like Actions"
 
-#: ../tiles/twitter.py:55
+#: ./sc/social/like/tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr "Geeft de hoogte op van een weergegeven widget. Overschrijft de waarde die is opgeslagen met het Widget ID. Moet groter zijn dan 200 pixels. Deze parameter geldt niet als een tweet-limiet is opgegeven."
 
-#: ../tiles/facebook.py:54
+#: ./sc/social/like/tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr "Geef de hoogte op van een widget. Overschrijft de waarde die bijhet Widget ID is opgeslagen. Moet groter zijn dan 70 pixels."
 
-#: ../tiles/facebook.py:42
+#: ./sc/social/like/tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Zet de maximale breedte van het widget tussen 180 en 500 pixels. Laat leeg om het widget automatisch aan te passen aan de breedte van de tegel."
 
-#: ../tiles/twitter.py:43
+#: ./sc/social/like/tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Zet de maximale breedte van het widget tussen 180 en 520 pixels. Laat leeg om het widget automatisch aan te passen aan de breedte van de tegel."
 
-#: ../controlpanel.py:13
+#: ./sc/social/like/controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr "Instellingen voor sc.social.like"
 
-#: ../plugins/telegram/plugin.pt:2
-#: ../plugins/whatsapp/templates/plugin.pt:2
-#: ../vocabularies.py:47
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/vocabularies.py:47
 msgid "Share"
 msgstr "Delen"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr "Deel per e-mail"
 
-#: ../plugins/facebook/templates/link.pt:12
+#: ./sc/social/like/plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr "Delen op Facebook"
 
-#: ../plugins/facebook/templates/link.pt:6
+#: ./sc/social/like/plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr "Delen op Facebook (open in nieuw venster)"
 
-#: ../plugins/gplus/templates/link.pt:9
+#: ./sc/social/like/plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr "Delen op Google+"
 
-#: ../plugins/gplus/templates/link.pt:3
+#: ./sc/social/like/plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr "Delen op Google+ (open in nieuw venster)"
 
-#: ../plugins/linkedin/templates/link.pt:9
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr "Delen op Linkedin"
 
-#: ../plugins/linkedin/templates/link.pt:3
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr "Delen op Linkedin (open in nieuw venster)"
 
-#: ../plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr "Deel op Telegram"
 
-#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "In WhatsApp delen"
 
-#: ../interfaces.py:163
+#: ./sc/social/like/interfaces.py:163
 msgid "Show number of likes"
 msgstr "Toon aantal likes."
 
-#: ../tiles/facebook.py:77
+#: ./sc/social/like/tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr "Toon profielfoto's als vrienden dit liken"
 
-#: ../tiles/facebook.py:87
+#: ./sc/social/like/tiles/facebook.py:87
 msgid "Show small header"
 msgstr "Toon klein titelgedeelte"
 
-#: ../controlpanel.py:12
-#: ../profiles/default/controlpanel.xml
+#: ./sc/social/like/controlpanel.py:12
+#: ./sc/social/like/profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: Like acties"
 
-#: ../tiles/facebook.py:36
+#: ./sc/social/like/tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr "De URL van de Facebookpagina"
 
-#: ../tiles/facebook.py:24
+#: ./sc/social/like/tiles/facebook.py:24
 msgid "Timeline"
 msgstr "Tijdlijn"
 
-#: ../plugins/twitter/templates/link.pt:9
+#: ./sc/social/like/plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr "Tweet het!"
 
-#: ../plugins/twitter/templates/link.pt:3
+#: ./sc/social/like/plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr "Tweet het! (open in nieuw venster)"
 
-#: ../tiles/twitter.py:73
+#: ./sc/social/like/tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr "Tweet limiet"
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr "Twittertegel"
 
-#: ../interfaces.py:176
+#: ./sc/social/like/interfaces.py:176
 msgid "Twitter nick"
 msgstr "Twitter naam (nick)"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr "De-installeer Social: Like Actions"
 
-#: ../interfaces.py:117
+#: ./sc/social/like/interfaces.py:117
 msgid "Verb to display"
 msgstr "Te tonen werkwoord"
 
-#: ../tiles/twitter.py:85
+#: ./sc/social/like/tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr "WAI-ARIA beleefdheid"
 
-#: ../tiles/twitter.py:36
+#: ./sc/social/like/tiles/twitter.py:36
 msgid "Widget ID"
 msgstr "Widget ID"
 
-#: ../tiles/facebook.py:41
-#: ../tiles/twitter.py:42
+#: ./sc/social/like/tiles/facebook.py:41
+#: ./sc/social/like/tiles/twitter.py:42
 msgid "Width"
 msgstr "Breedte"
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ../interfaces.py:131
+#: ./sc/social/like/interfaces.py:131
 msgid "help_admins"
 msgstr "Een komma-gescheiden lijst van de Facebook ID's van de paginabeheerders of het Facebook App ID."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ../interfaces.py:142
+#: ./sc/social/like/interfaces.py:142
 msgid "help_appid"
 msgstr "Een Facebook App ID. Dit is een verplichtt wanneer \"Volg geen gebruikers (tracking)\" is ingeschakeld."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ../interfaces.py:99
+#: ./sc/social/like/interfaces.py:99
 msgid "help_do_not_track"
 msgstr "Hiermee zal de website geen geavanceerde 'delen' widgets tonen, er komen alleen direct links te staan. Dit geeft een slechtere gebruikerservaring en functies als het aantal malen gedeeld staan uit, maar het verbetert de privacy van gebruikes. Geen 3rd party cookies worden hiermee gezet."
 
 #. Default: "Please select which plugins will be used"
-#: ../interfaces.py:77
+#: ./sc/social/like/interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Selecteer de ingeschakelde plugins. "
 
 #. Default: "Select buttons to be shown"
-#: ../interfaces.py:153
+#: ./sc/social/like/interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Te tonen knoppen"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ../interfaces.py:64
+#: ./sc/social/like/interfaces.py:64
 msgid "help_portal_types"
 msgstr "Kies de contenttypes waarbij de Social Media knoppen getoond worden."
 
 #. Default: "Choose your button style."
-#: ../interfaces.py:88
+#: ./sc/social/like/interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Kies de grafische stijl voor de knoppen."
 
 #. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
-#: ../interfaces.py:164
+#: ./sc/social/like/interfaces.py:164
 msgid "help_show_likes"
 msgstr "De Facebook knop toont ernaast of erboven het aantal gebruikers die deze pagina al geliked hebben."
 
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ../interfaces.py:118
+#: ./sc/social/like/interfaces.py:118
 msgid "help_verb_display"
 msgstr "Het werkwoord dat in de Facebook knop komt te staan. Op het moment zijn alelen \"Vind ik leuk\" en \"Aanbevelen\" beschikbaar."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ../interfaces.py:177
+#: ./sc/social/like/interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Vul de twitternaam in. Bijvoorbeeld planetplone"
 
-#: ../vocabularies.py:35
+#: ./sc/social/like/vocabularies.py:35
 msgid "horizontal"
 msgstr "horizontaal"
 
-#: ../vocabularies.py:36
+#: ./sc/social/like/vocabularies.py:36
 msgid "vertical"
 msgstr "verticaal"

--- a/sc/social/like/locales/nl/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/nl/LC_MESSAGES/sc.social.like.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social 2.2\n"
-"POT-Creation-Date: 2017-02-01 18:40+0000\n"
+"POT-Creation-Date: 2017-03-06 14:08+0000\n"
 "PO-Revision-Date: 2015-05-29 09:50 +0002\n"
 "Last-Translator: Fred van Dijk <f.van.dijk@zestsoftware.nl>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,304 +16,313 @@ msgstr ""
 "Language: nl\n"
 "X-Is-Fallback-For: nl-be nl-nl\n"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr "Een eenvoudige maar bruikbare Social Media integratie voor Plone"
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
-msgstr ""
+msgstr "Een tegel voor een Facebookpagina"
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
-msgstr ""
+msgstr "Een tegel voor een Twitter-tijdlijn"
 
-#: ./sc/social/like/tiles/twitter.py:86
+#: ../tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
-msgstr ""
+msgstr "Eem tijdlijn-wdiget is een live gedeelte op de webpagina waar tweets bijgewerkt worden zodra ze beschikbaar zijn. "
 
-#: ./sc/social/like/interfaces.py:130
+#: ../interfaces.py:130
 msgid "Admins"
 msgstr "Beheerders"
 
-#: ./sc/social/like/interfaces.py:141
+#: ../interfaces.py:141
 msgid "Application ID"
 msgstr "App ID"
 
-#: ./sc/social/like/interfaces.py:87
+#: ../interfaces.py:87
 msgid "Button style"
 msgstr "Knopstijl"
 
-#: ./sc/social/like/interfaces.py:63
+#: ../interfaces.py:63
 msgid "Content types"
 msgstr "Contenttypes"
 
-#: ./sc/social/like/tiles/twitter.py:26
+#: ../tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:74
+#: ../tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:98
+#: ../interfaces.py:98
 msgid "Do not track users"
 msgstr "Volg geen gebruikers (tracking)"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:25
+#: ../tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:35
+#: ../tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:152
+#: ../interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Facebook knoppen"
 
-#: ./sc/social/like/tiles/facebook.py:53
-#: ./sc/social/like/tiles/twitter.py:54
+#: ../tiles/facebook.py:53
+#: ../tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:72
+#: ../tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:82
+#: ../tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:24
+#: ../tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:23
+#: ../tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:41
+#: ../vocabularies.py:41
 msgid "Like"
 msgstr "Vind ik leuk (Like)"
 
-#: ./sc/social/like/tiles/facebook.py:26
+#: ../tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
+#: ../plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr "Pin vast!"
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
+#: ../plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr "Pin vast! (open in nieuw venster)"
 
-#: ./sc/social/like/interfaces.py:76
+#: ../interfaces.py:76
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ./sc/social/like/vocabularies.py:42
+#: ../vocabularies.py:42
 msgid "Recommend"
 msgstr "Aanbevelen"
 
-#: ./sc/social/like/tiles/twitter.py:25
+#: ../tiles/twitter.py:25
 msgid "Remove all borders within the widget"
-msgstr ""
+msgstr "Verwijder alle randen binnen het widget"
 
-#: ./sc/social/like/tiles/twitter.py:27
+#: ../tiles/twitter.py:27
 msgid "Remove the widget's background color"
-msgstr ""
+msgstr "Verwijder de achtergrondkleur van het widget"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Removes Social: Like Actions"
-msgstr ""
+msgstr "De-installeer Social: Like Actions"
 
-#: ./sc/social/like/tiles/twitter.py:55
+#: ../tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
-msgstr ""
+msgstr "Geeft de hoogte op van een weergegeven widget. Overschrijft de waarde die is opgeslagen met het Widget ID. Moet groter zijn dan 200 pixels. Deze parameter geldt niet als een tweet-limiet is opgegeven."
 
-#: ./sc/social/like/tiles/facebook.py:54
+#: ../tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
-msgstr ""
+msgstr "Geef de hoogte op van een widget. Overschrijft de waarde die bijhet Widget ID is opgeslagen. Moet groter zijn dan 70 pixels."
 
-#: ./sc/social/like/tiles/facebook.py:42
+#: ../tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
-msgstr ""
+msgstr "Zet de maximale breedte van het widget tussen 180 en 500 pixels. Laat leeg om het widget automatisch aan te passen aan de breedte van de tegel."
 
-#: ./sc/social/like/tiles/twitter.py:43
+#: ../tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
-msgstr ""
+msgstr "Zet de maximale breedte van het widget tussen 180 en 520 pixels. Laat leeg om het widget automatisch aan te passen aan de breedte van de tegel."
 
-#: ./sc/social/like/controlpanel.py:13
+#: ../controlpanel.py:13
 msgid "Settings for the sc.social.like package"
-msgstr ""
+msgstr "Instellingen voor sc.social.like"
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
-#: ./sc/social/like/vocabularies.py:47
+#: ../plugins/telegram/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ../vocabularies.py:47
 msgid "Share"
 msgstr "Delen"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Share by email"
-msgstr ""
+msgstr "Deel per e-mail"
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:12
+#: ../plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr "Delen op Facebook"
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:6
+#: ../plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr "Delen op Facebook (open in nieuw venster)"
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:9
+#: ../plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr "Delen op Google+"
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:3
+#: ../plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr "Delen op Google+ (open in nieuw venster)"
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
+#: ../plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr "Delen op Linkedin"
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
+#: ../plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr "Delen op Linkedin (open in nieuw venster)"
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ../plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
-msgstr ""
+msgstr "Deel op Telegram"
 
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "In WhatsApp delen"
 
-#: ./sc/social/like/tiles/facebook.py:77
+#: ../interfaces.py:163
+msgid "Show number of likes"
+msgstr "Toon aantal likes."
+
+#: ../tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
-msgstr ""
+msgstr "Toon profielfoto's als vrienden dit liken"
 
-#: ./sc/social/like/tiles/facebook.py:87
+#: ../tiles/facebook.py:87
 msgid "Show small header"
-msgstr ""
+msgstr "Toon klein titelgedeelte"
 
-#: ./sc/social/like/controlpanel.py:12
-#: ./sc/social/like/profiles/default/controlpanel.xml
+#: ../controlpanel.py:12
+#: ../profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: Like acties"
 
-#: ./sc/social/like/tiles/facebook.py:36
+#: ../tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
-msgstr ""
+msgstr "De URL van de Facebookpagina"
 
-#: ./sc/social/like/tiles/facebook.py:24
+#: ../tiles/facebook.py:24
 msgid "Timeline"
-msgstr ""
+msgstr "Tijdlijn"
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:9
+#: ../plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr "Tweet het!"
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:3
+#: ../plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr "Tweet het! (open in nieuw venster)"
 
-#: ./sc/social/like/tiles/twitter.py:73
+#: ../tiles/twitter.py:73
 msgid "Tweet limit"
-msgstr ""
+msgstr "Tweet limiet"
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "Twitter Tile"
-msgstr ""
+msgstr "Twittertegel"
 
-#: ./sc/social/like/interfaces.py:166
+#: ../interfaces.py:176
 msgid "Twitter nick"
 msgstr "Twitter naam (nick)"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
-msgstr ""
+msgstr "De-installeer Social: Like Actions"
 
-#: ./sc/social/like/interfaces.py:117
+#: ../interfaces.py:117
 msgid "Verb to display"
 msgstr "Te tonen werkwoord"
 
-#: ./sc/social/like/tiles/twitter.py:85
+#: ../tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
-msgstr ""
+msgstr "WAI-ARIA beleefdheid"
 
-#: ./sc/social/like/tiles/twitter.py:36
+#: ../tiles/twitter.py:36
 msgid "Widget ID"
-msgstr ""
+msgstr "Widget ID"
 
-#: ./sc/social/like/tiles/facebook.py:41
-#: ./sc/social/like/tiles/twitter.py:42
+#: ../tiles/facebook.py:41
+#: ../tiles/twitter.py:42
 msgid "Width"
-msgstr ""
+msgstr "Breedte"
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ./sc/social/like/interfaces.py:131
+#: ../interfaces.py:131
 msgid "help_admins"
 msgstr "Een komma-gescheiden lijst van de Facebook ID's van de paginabeheerders of het Facebook App ID."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ./sc/social/like/interfaces.py:142
+#: ../interfaces.py:142
 msgid "help_appid"
 msgstr "Een Facebook App ID. Dit is een verplichtt wanneer \"Volg geen gebruikers (tracking)\" is ingeschakeld."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ./sc/social/like/interfaces.py:99
+#: ../interfaces.py:99
 msgid "help_do_not_track"
 msgstr "Hiermee zal de website geen geavanceerde 'delen' widgets tonen, er komen alleen direct links te staan. Dit geeft een slechtere gebruikerservaring en functies als het aantal malen gedeeld staan uit, maar het verbetert de privacy van gebruikes. Geen 3rd party cookies worden hiermee gezet."
 
 #. Default: "Please select which plugins will be used"
-#: ./sc/social/like/interfaces.py:77
+#: ../interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Selecteer de ingeschakelde plugins. "
 
 #. Default: "Select buttons to be shown"
-#: ./sc/social/like/interfaces.py:153
+#: ../interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Te tonen knoppen"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ./sc/social/like/interfaces.py:64
+#: ../interfaces.py:64
 msgid "help_portal_types"
 msgstr "Kies de contenttypes waarbij de Social Media knoppen getoond worden."
 
 #. Default: "Choose your button style."
-#: ./sc/social/like/interfaces.py:88
+#: ../interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Kies de grafische stijl voor de knoppen."
 
+#. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
+#: ../interfaces.py:164
+msgid "help_show_likes"
+msgstr "De Facebook knop toont ernaast of erboven het aantal gebruikers die deze pagina al geliked hebben."
+
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ./sc/social/like/interfaces.py:118
+#: ../interfaces.py:118
 msgid "help_verb_display"
 msgstr "Het werkwoord dat in de Facebook knop komt te staan. Op het moment zijn alelen \"Vind ik leuk\" en \"Aanbevelen\" beschikbaar."
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ./sc/social/like/interfaces.py:167
+#: ../interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Vul de twitternaam in. Bijvoorbeeld planetplone"
 
-#: ./sc/social/like/vocabularies.py:35
+#: ../vocabularies.py:35
 msgid "horizontal"
 msgstr "horizontaal"
 
-#: ./sc/social/like/vocabularies.py:36
+#: ../vocabularies.py:36
 msgid "vertical"
 msgstr "verticaal"

--- a/sc/social/like/locales/pt_BR/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/pt_BR/LC_MESSAGES/sc.social.like.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social.like\n"
-"POT-Creation-Date: 2017-03-06 14:08+0000\n"
+"POT-Creation-Date: 2017-03-06 16:27+0000\n"
 "PO-Revision-Date: 2017-02-01 16:38-0200\n"
 "Last-Translator: Héctor Velarde <hector.velarde@gmail.com>\n"
 "Language-Team: Simples Consultoria <products@simplesconsultoria.com.br>\n"
@@ -17,315 +17,315 @@ msgstr ""
 "Language: pt\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr "Uma integração simples, mas útil, de redes sociais no Plone"
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr "Tile para integrar uma página do Facebook."
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr "Tile para integrar um timeline do Twitter."
 
-#: ../tiles/twitter.py:86
+#: ./sc/social/like/tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr "Um widget de timeline é uma região de uma página que puedo recebir actualizações na medida que novos tweets sejam disponibilizados. Quando informado como polite, as tecnologías de assistência notificarão os usuários de actualizações, mas não interrumpirão de jeito geral a tarefa actual e as atualizações terão baixa prioridade. Quando informado como assertive, as tecnologias de assistência notificarão imediatamente o usuário e poderão eliminar a fila de mensagens das atualizações anteriores."
 
-#: ../interfaces.py:130
+#: ./sc/social/like/interfaces.py:130
 msgid "Admins"
 msgstr "Administradores"
 
-#: ../interfaces.py:141
+#: ./sc/social/like/interfaces.py:141
 msgid "Application ID"
 msgstr "Application ID"
 
-#: ../interfaces.py:87
+#: ./sc/social/like/interfaces.py:87
 msgid "Button style"
 msgstr "Estilo dos botões"
 
-#: ../interfaces.py:63
+#: ./sc/social/like/interfaces.py:63
 msgid "Content types"
 msgstr "Tipos de conteúdo"
 
-#: ../tiles/twitter.py:26
+#: ./sc/social/like/tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr "Recortar e ocultar as barras de deslocamento do timeline"
 
-#: ../tiles/twitter.py:74
+#: ./sc/social/like/tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr "Mostrar um timeline expandido de entre 1 e 20 tweets. Deixar vazío para usar o valor padrão ou para especificar a altura do widget."
 
-#: ../interfaces.py:98
+#: ./sc/social/like/interfaces.py:98
 msgid "Do not track users"
 msgstr "No rastrear os usuários"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Email"
 msgstr "Email"
 
-#: ../tiles/facebook.py:25
+#: ./sc/social/like/tiles/facebook.py:25
 msgid "Events"
 msgstr "Eventos"
 
-#: ../tiles/facebook.py:35
+#: ./sc/social/like/tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr "Página do Facebook"
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr "Tile do Facebook"
 
-#: ../interfaces.py:152
+#: ./sc/social/like/interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Botões do Facebook"
 
-#: ../tiles/facebook.py:53
-#: ../tiles/twitter.py:54
+#: ./sc/social/like/tiles/facebook.py:53
+#: ./sc/social/like/tiles/twitter.py:54
 msgid "Height"
 msgstr "Altura"
 
-#: ../tiles/facebook.py:72
+#: ./sc/social/like/tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr "Ocultar a imagem do cabeçalho"
 
-#: ../tiles/facebook.py:82
+#: ./sc/social/like/tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ../tiles/twitter.py:24
+#: ./sc/social/like/tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr "Ocultar a imagem do rodapé"
 
-#: ../tiles/twitter.py:23
+#: ./sc/social/like/tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr "Ocultar o cabeçãlho do cabeçalho"
 
-#: ../vocabularies.py:41
+#: ./sc/social/like/vocabularies.py:41
 msgid "Like"
 msgstr "Curtir"
 
-#: ../tiles/facebook.py:26
+#: ./sc/social/like/tiles/facebook.py:26
 msgid "Messages"
 msgstr "Mensagens"
 
-#: ../plugins/pinterest/templates/link.pt:11
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr "Pin it!"
 
-#: ../plugins/pinterest/templates/link.pt:3
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr "Pin it! (abre em uma nova janela)"
 
-#: ../interfaces.py:76
+#: ./sc/social/like/interfaces.py:76
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../vocabularies.py:42
+#: ./sc/social/like/vocabularies.py:42
 msgid "Recommend"
 msgstr "Recomendar"
 
-#: ../tiles/twitter.py:25
+#: ./sc/social/like/tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr "Remover as bordas do widget"
 
-#: ../tiles/twitter.py:27
+#: ./sc/social/like/tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr "Remove a cor de fundo do widget"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ../tiles/twitter.py:55
+#: ./sc/social/like/tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr "Informar a altura do widget, sobrescrevendo o valor informado na configuração do mesmo. Deve ser maior de 200 pixeis. Nota: esse parâmetro no aplica se um limite de tweets for informado."
 
-#: ../tiles/facebook.py:54
+#: ./sc/social/like/tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr "Informar a altura do widget, sobrescrevendo o valor informado na configuração do mesmo. Deve ser maior de 70 pixeis."
 
-#: ../tiles/facebook.py:42
+#: ./sc/social/like/tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Informar a largura máxima do widget entre 180 y 520 pixeis. Deixar vazio para ajustar a largura do widget automaticamente no tile."
 
-#: ../tiles/twitter.py:43
+#: ./sc/social/like/tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Informar a largura máxima do widget entre 180 y 520 pixeis. Deixar vazio para ajustar a largura do widget automaticamente no tile."
 
-#: ../controlpanel.py:13
+#: ./sc/social/like/controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ../plugins/telegram/plugin.pt:2
-#: ../plugins/whatsapp/templates/plugin.pt:2
-#: ../vocabularies.py:47
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/vocabularies.py:47
 msgid "Share"
 msgstr "Compartilhar"
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr "Compartilhar por email"
 
-#: ../plugins/facebook/templates/link.pt:12
+#: ./sc/social/like/plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr "Compartilhar no Facebook"
 
-#: ../plugins/facebook/templates/link.pt:6
+#: ./sc/social/like/plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr "Compartilhar no Facebook (abre em uma nova janela)"
 
-#: ../plugins/gplus/templates/link.pt:9
+#: ./sc/social/like/plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr "Compartilhar no Google+"
 
-#: ../plugins/gplus/templates/link.pt:3
+#: ./sc/social/like/plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr "Compartilhar no Google+ (abre em uma nova janela)"
 
-#: ../plugins/linkedin/templates/link.pt:9
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr "Compartilhar no LinkedIn"
 
-#: ../plugins/linkedin/templates/link.pt:3
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr "Compartilhar no LinkedIn (abre em uma nova janela)"
 
-#: ../plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr "Compartilhar no Telegram"
 
-#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "Compartilhar no WhatsApp"
 
-#: ../interfaces.py:163
+#: ./sc/social/like/interfaces.py:163
 msgid "Show number of likes"
 msgstr ""
 
-#: ../tiles/facebook.py:77
+#: ./sc/social/like/tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr "Mostrar as imagens do perfil dos amigos que curtam isso"
 
-#: ../tiles/facebook.py:87
+#: ./sc/social/like/tiles/facebook.py:87
 msgid "Show small header"
 msgstr "Mostrar cabeçalho pequeno"
 
-#: ../controlpanel.py:12
-#: ../profiles/default/controlpanel.xml
+#: ./sc/social/like/controlpanel.py:12
+#: ./sc/social/like/profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: Ações de Curtir"
 
-#: ../tiles/facebook.py:36
+#: ./sc/social/like/tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr "A URL da página do Facebook."
 
-#: ../tiles/facebook.py:24
+#: ./sc/social/like/tiles/facebook.py:24
 msgid "Timeline"
 msgstr "Timeline"
 
-#: ../plugins/twitter/templates/link.pt:9
+#: ./sc/social/like/plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr "Tweet it!"
 
-#: ../plugins/twitter/templates/link.pt:3
+#: ./sc/social/like/plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr "Tweet it! (abre em uma nova janela)"
 
-#: ../tiles/twitter.py:73
+#: ./sc/social/like/tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr "Limite de tweets"
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr "Tile do Tweeter"
 
-#: ../interfaces.py:176
+#: ./sc/social/like/interfaces.py:176
 msgid "Twitter nick"
 msgstr "Usuário do Twitter"
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ../interfaces.py:117
+#: ./sc/social/like/interfaces.py:117
 msgid "Verb to display"
 msgstr "Verbo a ser exibido"
 
-#: ../tiles/twitter.py:85
+#: ./sc/social/like/tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr "Cortesia WAI-ARIA"
 
-#: ../tiles/twitter.py:36
+#: ./sc/social/like/tiles/twitter.py:36
 msgid "Widget ID"
 msgstr "ID do widget"
 
-#: ../tiles/facebook.py:41
-#: ../tiles/twitter.py:42
+#: ./sc/social/like/tiles/facebook.py:41
+#: ./sc/social/like/tiles/twitter.py:42
 msgid "Width"
 msgstr "Largura"
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ../interfaces.py:131
+#: ./sc/social/like/interfaces.py:131
 #, fuzzy
 msgid "help_admins"
 msgstr "Uma lista, separada por vírgulas, dos IDs dos administradores desta página ou o ID de uma aplicação da plataforma Facebook."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ../interfaces.py:142
+#: ./sc/social/like/interfaces.py:142
 msgid "help_appid"
 msgstr "ID da aplicação na plataforma Facebook. Isso é requerido quando a opcão de \"Não rastrear os usuários\" está habilitada."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ../interfaces.py:99
+#: ./sc/social/like/interfaces.py:99
 msgid "help_do_not_track"
 msgstr "Se habilitado, o site no provera os widgets avançados, mas simples links para os serviços. Isso limitará a experiência de usuário e as funcionalidades (como a conta de compartilhamentos) mas respeitará a privacidade dos usuários: nos se enviaram cookies a terceiros."
 
 #. Default: "Please select which plugins will be used"
-#: ../interfaces.py:77
+#: ./sc/social/like/interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Informe os plugins que serão usados"
 
 #. Default: "Select buttons to be shown"
-#: ../interfaces.py:153
+#: ./sc/social/like/interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Selecione os botões que serão mostrados"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ../interfaces.py:64
+#: ./sc/social/like/interfaces.py:64
 msgid "help_portal_types"
 msgstr "Indique quais tipos de conteúdo terão o viewlet de ações sociais."
 
 #. Default: "Choose your button style."
-#: ../interfaces.py:88
+#: ./sc/social/like/interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Qual o estilo dos botões."
 
 #. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
-#: ../interfaces.py:164
+#: ./sc/social/like/interfaces.py:164
 msgid "help_show_likes"
 msgstr ""
 
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ../interfaces.py:118
+#: ./sc/social/like/interfaces.py:118
 #, fuzzy
 msgid "help_verb_display"
 msgstr "Verbo a ser exibido no botão do Facebook. Atualmente apenas \"curtir\" e \"recomendar\" estão habilitados"
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ../interfaces.py:177
+#: ./sc/social/like/interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Informe seu usuário do Twitter. Ex: simplesconsultoria"
 
-#: ../vocabularies.py:35
+#: ./sc/social/like/vocabularies.py:35
 msgid "horizontal"
 msgstr "horizontal"
 
-#: ../vocabularies.py:36
+#: ./sc/social/like/vocabularies.py:36
 msgid "vertical"
 msgstr "vertical"

--- a/sc/social/like/locales/pt_BR/LC_MESSAGES/sc.social.like.po
+++ b/sc/social/like/locales/pt_BR/LC_MESSAGES/sc.social.like.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sc.social.like\n"
-"POT-Creation-Date: 2017-02-01 18:40+0000\n"
+"POT-Creation-Date: 2017-03-06 14:08+0000\n"
 "PO-Revision-Date: 2017-02-01 16:38-0200\n"
 "Last-Translator: Héctor Velarde <hector.velarde@gmail.com>\n"
 "Language-Team: Simples Consultoria <products@simplesconsultoria.com.br>\n"
@@ -17,306 +17,315 @@ msgstr ""
 "Language: pt\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr "Uma integração simples, mas útil, de redes sociais no Plone"
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr "Tile para integrar uma página do Facebook."
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr "Tile para integrar um timeline do Twitter."
 
-#: ./sc/social/like/tiles/twitter.py:86
+#: ../tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr "Um widget de timeline é uma região de uma página que puedo recebir actualizações na medida que novos tweets sejam disponibilizados. Quando informado como polite, as tecnologías de assistência notificarão os usuários de actualizações, mas não interrumpirão de jeito geral a tarefa actual e as atualizações terão baixa prioridade. Quando informado como assertive, as tecnologias de assistência notificarão imediatamente o usuário e poderão eliminar a fila de mensagens das atualizações anteriores."
 
-#: ./sc/social/like/interfaces.py:130
+#: ../interfaces.py:130
 msgid "Admins"
 msgstr "Administradores"
 
-#: ./sc/social/like/interfaces.py:141
+#: ../interfaces.py:141
 msgid "Application ID"
 msgstr "Application ID"
 
-#: ./sc/social/like/interfaces.py:87
+#: ../interfaces.py:87
 msgid "Button style"
 msgstr "Estilo dos botões"
 
-#: ./sc/social/like/interfaces.py:63
+#: ../interfaces.py:63
 msgid "Content types"
 msgstr "Tipos de conteúdo"
 
-#: ./sc/social/like/tiles/twitter.py:26
+#: ../tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr "Recortar e ocultar as barras de deslocamento do timeline"
 
-#: ./sc/social/like/tiles/twitter.py:74
+#: ../tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr "Mostrar um timeline expandido de entre 1 e 20 tweets. Deixar vazío para usar o valor padrão ou para especificar a altura do widget."
 
-#: ./sc/social/like/interfaces.py:98
+#: ../interfaces.py:98
 msgid "Do not track users"
 msgstr "No rastrear os usuários"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Email"
 msgstr "Email"
 
-#: ./sc/social/like/tiles/facebook.py:25
+#: ../tiles/facebook.py:25
 msgid "Events"
 msgstr "Eventos"
 
-#: ./sc/social/like/tiles/facebook.py:35
+#: ../tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr "Página do Facebook"
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr "Tile do Facebook"
 
-#: ./sc/social/like/interfaces.py:152
+#: ../interfaces.py:152
 msgid "Facebook buttons"
 msgstr "Botões do Facebook"
 
-#: ./sc/social/like/tiles/facebook.py:53
-#: ./sc/social/like/tiles/twitter.py:54
+#: ../tiles/facebook.py:53
+#: ../tiles/twitter.py:54
 msgid "Height"
 msgstr "Altura"
 
-#: ./sc/social/like/tiles/facebook.py:72
+#: ../tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr "Ocultar a imagem do cabeçalho"
 
-#: ./sc/social/like/tiles/facebook.py:82
+#: ../tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:24
+#: ../tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr "Ocultar a imagem do rodapé"
 
-#: ./sc/social/like/tiles/twitter.py:23
+#: ../tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr "Ocultar o cabeçãlho do cabeçalho"
 
-#: ./sc/social/like/vocabularies.py:41
+#: ../vocabularies.py:41
 msgid "Like"
 msgstr "Curtir"
 
-#: ./sc/social/like/tiles/facebook.py:26
+#: ../tiles/facebook.py:26
 msgid "Messages"
 msgstr "Mensagens"
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
+#: ../plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr "Pin it!"
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
+#: ../plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr "Pin it! (abre em uma nova janela)"
 
-#: ./sc/social/like/interfaces.py:76
+#: ../interfaces.py:76
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ./sc/social/like/vocabularies.py:42
+#: ../vocabularies.py:42
 msgid "Recommend"
 msgstr "Recomendar"
 
-#: ./sc/social/like/tiles/twitter.py:25
+#: ../tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr "Remover as bordas do widget"
 
-#: ./sc/social/like/tiles/twitter.py:27
+#: ../tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr "Remove a cor de fundo do widget"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:55
+#: ../tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr "Informar a altura do widget, sobrescrevendo o valor informado na configuração do mesmo. Deve ser maior de 200 pixeis. Nota: esse parâmetro no aplica se um limite de tweets for informado."
 
-#: ./sc/social/like/tiles/facebook.py:54
+#: ../tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr "Informar a altura do widget, sobrescrevendo o valor informado na configuração do mesmo. Deve ser maior de 70 pixeis."
 
-#: ./sc/social/like/tiles/facebook.py:42
+#: ../tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Informar a largura máxima do widget entre 180 y 520 pixeis. Deixar vazio para ajustar a largura do widget automaticamente no tile."
 
-#: ./sc/social/like/tiles/twitter.py:43
+#: ../tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr "Informar a largura máxima do widget entre 180 y 520 pixeis. Deixar vazio para ajustar a largura do widget automaticamente no tile."
 
-#: ./sc/social/like/controlpanel.py:13
+#: ../controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
-#: ./sc/social/like/vocabularies.py:47
+#: ../plugins/telegram/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ../vocabularies.py:47
 msgid "Share"
 msgstr "Compartilhar"
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr "Compartilhar por email"
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:12
+#: ../plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr "Compartilhar no Facebook"
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:6
+#: ../plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr "Compartilhar no Facebook (abre em uma nova janela)"
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:9
+#: ../plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr "Compartilhar no Google+"
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:3
+#: ../plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr "Compartilhar no Google+ (abre em uma nova janela)"
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
+#: ../plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr "Compartilhar no LinkedIn"
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
+#: ../plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr "Compartilhar no LinkedIn (abre em uma nova janela)"
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ../plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr "Compartilhar no Telegram"
 
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr "Compartilhar no WhatsApp"
 
-#: ./sc/social/like/tiles/facebook.py:77
+#: ../interfaces.py:163
+msgid "Show number of likes"
+msgstr ""
+
+#: ../tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr "Mostrar as imagens do perfil dos amigos que curtam isso"
 
-#: ./sc/social/like/tiles/facebook.py:87
+#: ../tiles/facebook.py:87
 msgid "Show small header"
 msgstr "Mostrar cabeçalho pequeno"
 
-#: ./sc/social/like/controlpanel.py:12
-#: ./sc/social/like/profiles/default/controlpanel.xml
+#: ../controlpanel.py:12
+#: ../profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr "Social Like"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr "Social: Ações de Curtir"
 
-#: ./sc/social/like/tiles/facebook.py:36
+#: ../tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr "A URL da página do Facebook."
 
-#: ./sc/social/like/tiles/facebook.py:24
+#: ../tiles/facebook.py:24
 msgid "Timeline"
 msgstr "Timeline"
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:9
+#: ../plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr "Tweet it!"
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:3
+#: ../plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr "Tweet it! (abre em uma nova janela)"
 
-#: ./sc/social/like/tiles/twitter.py:73
+#: ../tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr "Limite de tweets"
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr "Tile do Tweeter"
 
-#: ./sc/social/like/interfaces.py:166
+#: ../interfaces.py:176
 msgid "Twitter nick"
 msgstr "Usuário do Twitter"
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:117
+#: ../interfaces.py:117
 msgid "Verb to display"
 msgstr "Verbo a ser exibido"
 
-#: ./sc/social/like/tiles/twitter.py:85
+#: ../tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr "Cortesia WAI-ARIA"
 
-#: ./sc/social/like/tiles/twitter.py:36
+#: ../tiles/twitter.py:36
 msgid "Widget ID"
 msgstr "ID do widget"
 
-#: ./sc/social/like/tiles/facebook.py:41
-#: ./sc/social/like/tiles/twitter.py:42
+#: ../tiles/facebook.py:41
+#: ../tiles/twitter.py:42
 msgid "Width"
 msgstr "Largura"
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ./sc/social/like/interfaces.py:131
+#: ../interfaces.py:131
 #, fuzzy
 msgid "help_admins"
 msgstr "Uma lista, separada por vírgulas, dos IDs dos administradores desta página ou o ID de uma aplicação da plataforma Facebook."
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ./sc/social/like/interfaces.py:142
+#: ../interfaces.py:142
 msgid "help_appid"
 msgstr "ID da aplicação na plataforma Facebook. Isso é requerido quando a opcão de \"Não rastrear os usuários\" está habilitada."
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ./sc/social/like/interfaces.py:99
+#: ../interfaces.py:99
 msgid "help_do_not_track"
 msgstr "Se habilitado, o site no provera os widgets avançados, mas simples links para os serviços. Isso limitará a experiência de usuário e as funcionalidades (como a conta de compartilhamentos) mas respeitará a privacidade dos usuários: nos se enviaram cookies a terceiros."
 
 #. Default: "Please select which plugins will be used"
-#: ./sc/social/like/interfaces.py:77
+#: ../interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr "Informe os plugins que serão usados"
 
 #. Default: "Select buttons to be shown"
-#: ./sc/social/like/interfaces.py:153
+#: ../interfaces.py:153
 msgid "help_fbbuttons"
 msgstr "Selecione os botões que serão mostrados"
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ./sc/social/like/interfaces.py:64
+#: ../interfaces.py:64
 msgid "help_portal_types"
 msgstr "Indique quais tipos de conteúdo terão o viewlet de ações sociais."
 
 #. Default: "Choose your button style."
-#: ./sc/social/like/interfaces.py:88
+#: ../interfaces.py:88
 msgid "help_selected_buttons"
 msgstr "Qual o estilo dos botões."
 
+#. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
+#: ../interfaces.py:164
+msgid "help_show_likes"
+msgstr ""
+
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ./sc/social/like/interfaces.py:118
+#: ../interfaces.py:118
 #, fuzzy
 msgid "help_verb_display"
 msgstr "Verbo a ser exibido no botão do Facebook. Atualmente apenas \"curtir\" e \"recomendar\" estão habilitados"
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ./sc/social/like/interfaces.py:167
+#: ../interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr "Informe seu usuário do Twitter. Ex: simplesconsultoria"
 
-#: ./sc/social/like/vocabularies.py:35
+#: ../vocabularies.py:35
 msgid "horizontal"
 msgstr "horizontal"
 
-#: ./sc/social/like/vocabularies.py:36
+#: ../vocabularies.py:36
 msgid "vertical"
 msgstr "vertical"

--- a/sc/social/like/locales/sc.social.like.pot
+++ b/sc/social/like/locales/sc.social.like.pot
@@ -1,7 +1,10 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-01 18:40+0000\n"
+"POT-Creation-Date: 2017-03-06 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,306 +15,315 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
+"Domain: sc.social.like\n"
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:86
+#: ../tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:130
+#: ../interfaces.py:130
 msgid "Admins"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:141
+#: ../interfaces.py:141
 msgid "Application ID"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:87
+#: ../interfaces.py:87
 msgid "Button style"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:63
+#: ../interfaces.py:63
 msgid "Content types"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:26
+#: ../tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:74
+#: ../tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:98
+#: ../interfaces.py:98
 msgid "Do not track users"
 msgstr ""
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:25
+#: ../tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:35
+#: ../tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:19
+#: ../tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:152
+#: ../interfaces.py:152
 msgid "Facebook buttons"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:53
-#: ./sc/social/like/tiles/twitter.py:54
+#: ../tiles/facebook.py:53
+#: ../tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:72
+#: ../tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:82
+#: ../tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:24
+#: ../tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:23
+#: ../tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:41
+#: ../vocabularies.py:41
 msgid "Like"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:26
+#: ../tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
+#: ../plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr ""
 
-#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
+#: ../plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:76
+#: ../interfaces.py:76
 msgid "Plugins"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:42
+#: ../vocabularies.py:42
 msgid "Recommend"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:25
+#: ../tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:27
+#: ../tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr ""
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:55
+#: ../tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:54
+#: ../tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:42
+#: ../tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:43
+#: ../tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ./sc/social/like/controlpanel.py:13
+#: ../controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
-#: ./sc/social/like/vocabularies.py:47
+#: ../plugins/telegram/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ../vocabularies.py:47
 msgid "Share"
 msgstr ""
 
-#: ./sc/social/like/plugins/email/plugin.pt:2
+#: ../plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr ""
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:12
+#: ../plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr ""
 
-#: ./sc/social/like/plugins/facebook/templates/link.pt:6
+#: ../plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:9
+#: ../plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr ""
 
-#: ./sc/social/like/plugins/gplus/templates/link.pt:3
+#: ../plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
+#: ../plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr ""
 
-#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
+#: ../plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ../plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr ""
 
-#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ../plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:77
+#: ../interfaces.py:163
+msgid "Show number of likes"
+msgstr ""
+
+#: ../tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:87
+#: ../tiles/facebook.py:87
 msgid "Show small header"
 msgstr ""
 
-#: ./sc/social/like/controlpanel.py:12
-#: ./sc/social/like/profiles/default/controlpanel.xml
+#: ../controlpanel.py:12
+#: ../profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr ""
 
-#: ./sc/social/like/profiles.zcml:14
+#: ../profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:36
+#: ../tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:24
+#: ../tiles/facebook.py:24
 msgid "Timeline"
 msgstr ""
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:9
+#: ../plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr ""
 
-#: ./sc/social/like/plugins/twitter/templates/link.pt:3
+#: ../plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:73
+#: ../tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr ""
 
-#: ./sc/social/like/tiles/configure.zcml:31
+#: ../tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:166
+#: ../interfaces.py:176
 msgid "Twitter nick"
 msgstr ""
 
-#: ./sc/social/like/profiles.zcml:23
+#: ../profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ./sc/social/like/interfaces.py:117
+#: ../interfaces.py:117
 msgid "Verb to display"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:85
+#: ../tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr ""
 
-#: ./sc/social/like/tiles/twitter.py:36
+#: ../tiles/twitter.py:36
 msgid "Widget ID"
 msgstr ""
 
-#: ./sc/social/like/tiles/facebook.py:41
-#: ./sc/social/like/tiles/twitter.py:42
+#: ../tiles/facebook.py:41
+#: ../tiles/twitter.py:42
 msgid "Width"
 msgstr ""
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ./sc/social/like/interfaces.py:131
+#: ../interfaces.py:131
 msgid "help_admins"
 msgstr ""
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ./sc/social/like/interfaces.py:142
+#: ../interfaces.py:142
 msgid "help_appid"
 msgstr ""
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ./sc/social/like/interfaces.py:99
+#: ../interfaces.py:99
 msgid "help_do_not_track"
 msgstr ""
 
 #. Default: "Please select which plugins will be used"
-#: ./sc/social/like/interfaces.py:77
+#: ../interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr ""
 
 #. Default: "Select buttons to be shown"
-#: ./sc/social/like/interfaces.py:153
+#: ../interfaces.py:153
 msgid "help_fbbuttons"
 msgstr ""
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ./sc/social/like/interfaces.py:64
+#: ../interfaces.py:64
 msgid "help_portal_types"
 msgstr ""
 
 #. Default: "Choose your button style."
-#: ./sc/social/like/interfaces.py:88
+#: ../interfaces.py:88
 msgid "help_selected_buttons"
 msgstr ""
 
+#. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
+#: ../interfaces.py:164
+msgid "help_show_likes"
+msgstr ""
+
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ./sc/social/like/interfaces.py:118
+#: ../interfaces.py:118
 msgid "help_verb_display"
 msgstr ""
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ./sc/social/like/interfaces.py:167
+#: ../interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:35
+#: ../vocabularies.py:35
 msgid "horizontal"
 msgstr ""
 
-#: ./sc/social/like/vocabularies.py:36
+#: ../vocabularies.py:36
 msgid "vertical"
 msgstr ""

--- a/sc/social/like/locales/sc.social.like.pot
+++ b/sc/social/like/locales/sc.social.like.pot
@@ -1,10 +1,7 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-06 14:08+0000\n"
+"POT-Creation-Date: 2017-03-06 16:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,315 +12,315 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: sc.social.like\n"
+"Domain: DOMAIN\n"
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "A simple, yet useful, social networking integration for Plone"
 msgstr ""
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "A tile that embeds a Facebook Page."
 msgstr ""
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "A tile that embeds a Twitter timeline."
 msgstr ""
 
-#: ../tiles/twitter.py:86
+#: ./sc/social/like/tiles/twitter.py:86
 msgid "A timeline widget is a live region of a page which may receive updates as new tweets become available. When specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates."
 msgstr ""
 
-#: ../interfaces.py:130
+#: ./sc/social/like/interfaces.py:130
 msgid "Admins"
 msgstr ""
 
-#: ../interfaces.py:141
+#: ./sc/social/like/interfaces.py:141
 msgid "Application ID"
 msgstr ""
 
-#: ../interfaces.py:87
+#: ./sc/social/like/interfaces.py:87
 msgid "Button style"
 msgstr ""
 
-#: ../interfaces.py:63
+#: ./sc/social/like/interfaces.py:63
 msgid "Content types"
 msgstr ""
 
-#: ../tiles/twitter.py:26
+#: ./sc/social/like/tiles/twitter.py:26
 msgid "Crop and hides the main timeline scrollbar"
 msgstr ""
 
-#: ../tiles/twitter.py:74
+#: ./sc/social/like/tiles/twitter.py:74
 msgid "Display an expanded timeline of between 1 and 20 tweets. Leave it empty to use the default or to set the height of the widget."
 msgstr ""
 
-#: ../interfaces.py:98
+#: ./sc/social/like/interfaces.py:98
 msgid "Do not track users"
 msgstr ""
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Email"
 msgstr ""
 
-#: ../tiles/facebook.py:25
+#: ./sc/social/like/tiles/facebook.py:25
 msgid "Events"
 msgstr ""
 
-#: ../tiles/facebook.py:35
+#: ./sc/social/like/tiles/facebook.py:35
 msgid "Facebook Page"
 msgstr ""
 
-#: ../tiles/configure.zcml:19
+#: ./sc/social/like/tiles/configure.zcml:19
 msgid "Facebook Tile"
 msgstr ""
 
-#: ../interfaces.py:152
+#: ./sc/social/like/interfaces.py:152
 msgid "Facebook buttons"
 msgstr ""
 
-#: ../tiles/facebook.py:53
-#: ../tiles/twitter.py:54
+#: ./sc/social/like/tiles/facebook.py:53
+#: ./sc/social/like/tiles/twitter.py:54
 msgid "Height"
 msgstr ""
 
-#: ../tiles/facebook.py:72
+#: ./sc/social/like/tiles/facebook.py:72
 msgid "Hide cover photo in the header"
 msgstr ""
 
-#: ../tiles/facebook.py:82
+#: ./sc/social/like/tiles/facebook.py:82
 msgid "Hide the custom call to action button (if available)"
 msgstr ""
 
-#: ../tiles/twitter.py:24
+#: ./sc/social/like/tiles/twitter.py:24
 msgid "Hide the timeline footer"
 msgstr ""
 
-#: ../tiles/twitter.py:23
+#: ./sc/social/like/tiles/twitter.py:23
 msgid "Hide the timeline header"
 msgstr ""
 
-#: ../vocabularies.py:41
+#: ./sc/social/like/vocabularies.py:41
 msgid "Like"
 msgstr ""
 
-#: ../tiles/facebook.py:26
+#: ./sc/social/like/tiles/facebook.py:26
 msgid "Messages"
 msgstr ""
 
-#: ../plugins/pinterest/templates/link.pt:11
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:11
 msgid "Pin it!"
 msgstr ""
 
-#: ../plugins/pinterest/templates/link.pt:3
+#: ./sc/social/like/plugins/pinterest/templates/link.pt:3
 msgid "Pin it! (open in new window)"
 msgstr ""
 
-#: ../interfaces.py:76
+#: ./sc/social/like/interfaces.py:76
 msgid "Plugins"
 msgstr ""
 
-#: ../vocabularies.py:42
+#: ./sc/social/like/vocabularies.py:42
 msgid "Recommend"
 msgstr ""
 
-#: ../tiles/twitter.py:25
+#: ./sc/social/like/tiles/twitter.py:25
 msgid "Remove all borders within the widget"
 msgstr ""
 
-#: ../tiles/twitter.py:27
+#: ./sc/social/like/tiles/twitter.py:27
 msgid "Remove the widget's background color"
 msgstr ""
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Removes Social: Like Actions"
 msgstr ""
 
-#: ../tiles/twitter.py:55
+#: ./sc/social/like/tiles/twitter.py:55
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 200 pixels. Note: this parameter does not apply if a tweet limit has been specified."
 msgstr ""
 
-#: ../tiles/facebook.py:54
+#: ./sc/social/like/tiles/facebook.py:54
 msgid "Set the height of a displayed widget, overriding the value stored with the widget ID. Must be greater than 70 pixels. "
 msgstr ""
 
-#: ../tiles/facebook.py:42
+#: ./sc/social/like/tiles/facebook.py:42
 msgid "Set the maximum width of the widget between 180 and 500 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ../tiles/twitter.py:43
+#: ./sc/social/like/tiles/twitter.py:43
 msgid "Set the maximum width of the widget between 180 and 520 pixels. Leave it empty to automatically adjust the widget to the width of the tile."
 msgstr ""
 
-#: ../controlpanel.py:13
+#: ./sc/social/like/controlpanel.py:13
 msgid "Settings for the sc.social.like package"
 msgstr ""
 
-#: ../plugins/telegram/plugin.pt:2
-#: ../plugins/whatsapp/templates/plugin.pt:2
-#: ../vocabularies.py:47
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/vocabularies.py:47
 msgid "Share"
 msgstr ""
 
-#: ../plugins/email/plugin.pt:2
+#: ./sc/social/like/plugins/email/plugin.pt:2
 msgid "Share by email"
 msgstr ""
 
-#: ../plugins/facebook/templates/link.pt:12
+#: ./sc/social/like/plugins/facebook/templates/link.pt:12
 msgid "Share on Facebook"
 msgstr ""
 
-#: ../plugins/facebook/templates/link.pt:6
+#: ./sc/social/like/plugins/facebook/templates/link.pt:6
 msgid "Share on Facebook (open in new window)"
 msgstr ""
 
-#: ../plugins/gplus/templates/link.pt:9
+#: ./sc/social/like/plugins/gplus/templates/link.pt:9
 msgid "Share on Google+"
 msgstr ""
 
-#: ../plugins/gplus/templates/link.pt:3
+#: ./sc/social/like/plugins/gplus/templates/link.pt:3
 msgid "Share on Google+ (open in new window)"
 msgstr ""
 
-#: ../plugins/linkedin/templates/link.pt:9
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:9
 msgid "Share on Linkedin"
 msgstr ""
 
-#: ../plugins/linkedin/templates/link.pt:3
+#: ./sc/social/like/plugins/linkedin/templates/link.pt:3
 msgid "Share on Linkedin (open in new window)"
 msgstr ""
 
-#: ../plugins/telegram/plugin.pt:2
+#: ./sc/social/like/plugins/telegram/plugin.pt:2
 msgid "Share on Telegram"
 msgstr ""
 
-#: ../plugins/whatsapp/templates/plugin.pt:2
+#: ./sc/social/like/plugins/whatsapp/templates/plugin.pt:2
 msgid "Share on WhatsApp"
 msgstr ""
 
-#: ../interfaces.py:163
+#: ./sc/social/like/interfaces.py:163
 msgid "Show number of likes"
 msgstr ""
 
-#: ../tiles/facebook.py:77
+#: ./sc/social/like/tiles/facebook.py:77
 msgid "Show profile photos when friends like this"
 msgstr ""
 
-#: ../tiles/facebook.py:87
+#: ./sc/social/like/tiles/facebook.py:87
 msgid "Show small header"
 msgstr ""
 
-#: ../controlpanel.py:12
-#: ../profiles/default/controlpanel.xml
+#: ./sc/social/like/controlpanel.py:12
+#: ./sc/social/like/profiles/default/controlpanel.xml
 msgid "Social Like"
 msgstr ""
 
-#: ../profiles.zcml:14
+#: ./sc/social/like/profiles.zcml:14
 msgid "Social: Like Actions"
 msgstr ""
 
-#: ../tiles/facebook.py:36
+#: ./sc/social/like/tiles/facebook.py:36
 msgid "The URL of the Facebook Page."
 msgstr ""
 
-#: ../tiles/facebook.py:24
+#: ./sc/social/like/tiles/facebook.py:24
 msgid "Timeline"
 msgstr ""
 
-#: ../plugins/twitter/templates/link.pt:9
+#: ./sc/social/like/plugins/twitter/templates/link.pt:9
 msgid "Tweet it!"
 msgstr ""
 
-#: ../plugins/twitter/templates/link.pt:3
+#: ./sc/social/like/plugins/twitter/templates/link.pt:3
 msgid "Tweet it! (open in new window)"
 msgstr ""
 
-#: ../tiles/twitter.py:73
+#: ./sc/social/like/tiles/twitter.py:73
 msgid "Tweet limit"
 msgstr ""
 
-#: ../tiles/configure.zcml:31
+#: ./sc/social/like/tiles/configure.zcml:31
 msgid "Twitter Tile"
 msgstr ""
 
-#: ../interfaces.py:176
+#: ./sc/social/like/interfaces.py:176
 msgid "Twitter nick"
 msgstr ""
 
-#: ../profiles.zcml:23
+#: ./sc/social/like/profiles.zcml:23
 msgid "Uninstall Social: Like Actions"
 msgstr ""
 
-#: ../interfaces.py:117
+#: ./sc/social/like/interfaces.py:117
 msgid "Verb to display"
 msgstr ""
 
-#: ../tiles/twitter.py:85
+#: ./sc/social/like/tiles/twitter.py:85
 msgid "WAI-ARIA politeness"
 msgstr ""
 
-#: ../tiles/twitter.py:36
+#: ./sc/social/like/tiles/twitter.py:36
 msgid "Widget ID"
 msgstr ""
 
-#: ../tiles/facebook.py:41
-#: ../tiles/twitter.py:42
+#: ./sc/social/like/tiles/facebook.py:41
+#: ./sc/social/like/tiles/twitter.py:42
 msgid "Width"
 msgstr ""
 
 #. Default: "A comma-separated list of either the Facebook IDs of page administrators."
-#: ../interfaces.py:131
+#: ./sc/social/like/interfaces.py:131
 msgid "help_admins"
 msgstr ""
 
 #. Default: "A Facebook Platform application ID.\nThis is required when \"Do not track users\" option is enabled."
-#: ../interfaces.py:142
+#: ./sc/social/like/interfaces.py:142
 msgid "help_appid"
 msgstr ""
 
 #. Default: "If enabled, the site will not provide advanced sharing widgets , instead simple links will be used.\nThis will limits user experience and features (like the share count) but will enhance users privacy: no 3rd party cookies will be sent to users."
-#: ../interfaces.py:99
+#: ./sc/social/like/interfaces.py:99
 msgid "help_do_not_track"
 msgstr ""
 
 #. Default: "Please select which plugins will be used"
-#: ../interfaces.py:77
+#: ./sc/social/like/interfaces.py:77
 msgid "help_enabled_plugins"
 msgstr ""
 
 #. Default: "Select buttons to be shown"
-#: ../interfaces.py:153
+#: ./sc/social/like/interfaces.py:153
 msgid "help_fbbuttons"
 msgstr ""
 
 #. Default: "Please select content types in which the viewlet will be applied."
-#: ../interfaces.py:64
+#: ./sc/social/like/interfaces.py:64
 msgid "help_portal_types"
 msgstr ""
 
 #. Default: "Choose your button style."
-#: ../interfaces.py:88
+#: ./sc/social/like/interfaces.py:88
 msgid "help_selected_buttons"
 msgstr ""
 
 #. Default: "If enabled, the facebook button will show the number of facebook users who have already liked this page."
-#: ../interfaces.py:164
+#: ./sc/social/like/interfaces.py:164
 msgid "help_show_likes"
 msgstr ""
 
 #. Default: "The verb to display in the facebook button. Currently only \"like\" and \"recommend\" are supported."
-#: ../interfaces.py:118
+#: ./sc/social/like/interfaces.py:118
 msgid "help_verb_display"
 msgstr ""
 
 #. Default: "Enter your twitter nick. eg. simplesconsultoria"
-#: ../interfaces.py:177
+#: ./sc/social/like/interfaces.py:177
 msgid "help_your_twitter_nick"
 msgstr ""
 
-#: ../vocabularies.py:35
+#: ./sc/social/like/vocabularies.py:35
 msgid "horizontal"
 msgstr ""
 
-#: ../vocabularies.py:36
+#: ./sc/social/like/vocabularies.py:36
 msgid "vertical"
 msgstr ""

--- a/sc/social/like/plugins/facebook/__init__.py
+++ b/sc/social/like/plugins/facebook/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding:utf-8 -*-
+# -*- coding:utf-8 -*-:
+
 from sc.social.like.plugins import IPlugin
 from sc.social.like.plugins import Plugin
 from zope.interface import implementer

--- a/sc/social/like/plugins/facebook/browser.py
+++ b/sc/social/like/plugins/facebook/browser.py
@@ -96,18 +96,26 @@ class PluginView(BrowserView):
 
     @property
     def typebutton(self):
-        record = ISocialLikeSettings.__identifier__ + '.typebutton'
+        typerecord = ISocialLikeSettings.__identifier__ + '.typebutton'
+        showlikesrecord = ISocialLikeSettings.__identifier__ + '.fbshowlikes'
+
         try:
-            typebutton = api.portal.get_registry_record(record)
+            typebutton = api.portal.get_registry_record(typerecord)
+            fbshowlikes = api.portal.get_registry_record(showlikesrecord)
         except InvalidParameterError:
             typebutton = ''
-
-        if typebutton == 'horizontal':
+            fbshowlikes = True
+        if typebutton == 'horizontal' and fbshowlikes:
             typebutton = 'button_count'
             self.width = '90px'
-        else:
+        elif typebutton == 'vertical' and fbshowlikes:
             typebutton = 'box_count'
             self.width = '55px'
+        else:
+            # no counts, show simple button
+            typebutton = 'button'
+            self.width = '55px'
+
         return typebutton
 
     @property

--- a/sc/social/like/profiles/default/metadata.xml
+++ b/sc/social/like/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3043</version>
+  <version>3044</version>
 </metadata>

--- a/sc/social/like/profiles/uninstall/registry.xml
+++ b/sc/social/like/profiles/uninstall/registry.xml
@@ -10,5 +10,6 @@
   <record name="sc.social.like.interfaces.ISocialLikeSettings.facebook_username" delete="true"/>
   <record name="sc.social.like.interfaces.ISocialLikeSettings.facebook_app_id" delete="true"/>
   <record name="sc.social.like.interfaces.ISocialLikeSettings.fbbuttons" delete="true"/>
+  <record name="sc.social.like.interfaces.ISocialLikeSettings.fbshowlikes" delete="true"/>
   <record name="sc.social.like.interfaces.ISocialLikeSettings.twitter_username" delete="true"/>
 </registry>

--- a/sc/social/like/tests/test_controlpanel.py
+++ b/sc/social/like/tests/test_controlpanel.py
@@ -94,6 +94,10 @@ class RegistryTestCase(unittest.TestCase):
         self.assertTrue(hasattr(self.settings, 'fbbuttons'))
         self.assertEqual(self.settings.fbbuttons, (u'Like',))
 
+    def test_fbshowlikes_record_in_registry(self):
+        self.assertTrue(hasattr(self.settings, 'fbshowlikes'))
+        self.assertEqual(self.settings.fbshowlikes, True)
+
     def test_twitter_username_record_in_registry(self):
         self.assertTrue(hasattr(self.settings, 'twitter_username'))
         self.assertEqual(self.settings.twitter_username, '')
@@ -113,6 +117,7 @@ class RegistryTestCase(unittest.TestCase):
             ISocialLikeSettings.__identifier__ + '.facebook_username',
             ISocialLikeSettings.__identifier__ + '.facebook_app_id',
             ISocialLikeSettings.__identifier__ + '.fbbuttons',
+            ISocialLikeSettings.__identifier__ + '.fbshowlikes',
             ISocialLikeSettings.__identifier__ + '.twitter_username',
         ]
 

--- a/sc/social/like/tests/test_plugin_facebook.py
+++ b/sc/social/like/tests/test_plugin_facebook.py
@@ -272,6 +272,20 @@ class PluginViewsTest(unittest.TestCase):
         self.assertEqual(view.typebutton, 'box_count')
         self.assertEqual(view.width, '55px')
 
+        # disable show number of likes on vertical
+        self.settings.typebutton = 'vertical'
+        self.settings.fbshowlikes = False
+        view = portal.restrictedTraverse(plugin_view)
+        self.assertEqual(view.typebutton, 'button')
+        self.assertEqual(view.width, '55px')
+
+        # horizontal without numbers is also button
+        self.settings.typebutton = 'horizontal'
+        self.settings.fbshowlikes = False
+        view = portal.restrictedTraverse(plugin_view)
+        self.assertEqual(view.typebutton, 'button')
+        self.assertEqual(view.width, '55px')
+
 
 class LanguageCodeTest(unittest.TestCase):
 

--- a/sc/social/like/tests/test_upgrades.py
+++ b/sc/social/like/tests/test_upgrades.py
@@ -225,15 +225,15 @@ class To3044TestCase(UpgradeTestCaseBase):
         step = self.get_upgrade_step(title)
         assert step is not None
 
-        # remove registry settings
+        # simulate state on previous version
         from plone.registry.interfaces import IRegistry
-        from sc.social.like.config import PROJECTNAME
         from sc.social.like.interfaces import ISocialLikeSettings
         from zope.component import getUtility
-        profile = 'profile-{0}:uninstall'.format(PROJECTNAME)
-        setup_tool = api.portal.get_tool(name='portal_setup')
-        setup_tool.runImportStepFromProfile(profile, 'plone.app.registry')
         registry = getUtility(IRegistry)
+        record = ISocialLikeSettings.__identifier__ + '.fbshowlikes'
+        del registry.records[record]
+        assert record not in registry
+
         with self.assertRaises(KeyError):
             registry.forInterface(ISocialLikeSettings)
 

--- a/sc/social/like/tests/test_upgrades.py
+++ b/sc/social/like/tests/test_upgrades.py
@@ -208,3 +208,38 @@ class To3043TestCase(UpgradeTestCaseBase):
         version = self.setup.getLastVersionForProfile(self.profile_id)[0]
         self.assertGreaterEqual(int(version), int(self.to_version))
         self.assertEqual(self.total_steps, 2)
+
+
+class To3044TestCase(UpgradeTestCaseBase):
+
+    def setUp(self):
+        UpgradeTestCaseBase.setUp(self, u'3043', u'3044')
+
+    def test_upgrade_to_3043_registrations(self):
+        version = self.setup.getLastVersionForProfile(self.profile_id)[0]
+        self.assertGreaterEqual(int(version), int(self.to_version))
+        self.assertEqual(self.total_steps, 1)
+
+    def test_add_fbshowlikes_record(self):
+        title = u'Add registry setting to show/hide number of likes'
+        step = self.get_upgrade_step(title)
+        assert step is not None
+
+        # remove registry settings
+        from plone.registry.interfaces import IRegistry
+        from sc.social.like.config import PROJECTNAME
+        from sc.social.like.interfaces import ISocialLikeSettings
+        from zope.component import getUtility
+        profile = 'profile-{0}:uninstall'.format(PROJECTNAME)
+        setup_tool = api.portal.get_tool(name='portal_setup')
+        setup_tool.runImportStepFromProfile(profile, 'plone.app.registry')
+        registry = getUtility(IRegistry)
+        with self.assertRaises(KeyError):
+            registry.forInterface(ISocialLikeSettings)
+
+        # run the upgrade step to validate the update
+        self.execute_upgrade_step(step)
+
+        # Test if our setting is there and set
+        settings = registry.forInterface(ISocialLikeSettings)
+        self.assertEqual(settings.fbshowlikes, True)

--- a/sc/social/like/upgrades/configure.zcml
+++ b/sc/social/like/upgrades/configure.zcml
@@ -9,5 +9,6 @@
     <include package=".v3041" />
     <include package=".v3042" />
     <include package=".v3043" />
+    <include package=".v3044" />
 
 </configure>

--- a/sc/social/like/upgrades/v3044/configure.zcml
+++ b/sc/social/like/upgrades/v3044/configure.zcml
@@ -8,7 +8,7 @@
       profile="sc.social.like:default">
 
     <genericsetup:upgradeDepends
-        title="Add registry setting"
+        title="Add registry setting to show/hide number of likes"
         description="Add fbshowlikes setting to the registry"
         import_steps="plone.app.registry"
         />

--- a/sc/social/like/upgrades/v3044/configure.zcml
+++ b/sc/social/like/upgrades/v3044/configure.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:upgradeSteps
+      source="3043"
+      destination="3044"
+      profile="sc.social.like:default">
+
+    <genericsetup:upgradeDepends
+        title="Add registry setting"
+        description="Add fbshowlikes setting to the registry"
+        import_steps="plone.app.registry"
+        />
+
+  </genericsetup:upgradeSteps>
+
+</configure>


### PR DESCRIPTION
By default the Facebook plugin still shows the number of likes.
Updated translation files and translated Dutch.