### PR TITLE
Add a way to extend default metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 2.13b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Add a way to extend default metadata using adapters
+  [erral]
+
 - Complete Basque translation.
   [erral]
 

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,37 @@ The following basic metadata is included on content types with Social Media beha
 * ``og:image``: the 'large' scale of the lead image of the item, if present;
   you can define a fallback image to be used in content that lacks lead image on the control panel configlet
 
+Extending Open Graph metadata
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also extend the basic metadata with additional tags. Open Graph protocol supports
+additional metatags for example to mark videos. To provide these additional metatags you
+need to register an adapter implementing `IAdditionalMetatags`. For example, to provide additional
+metatags for objecs implementing INewsItem interface, you will need something like::
+
+  from zope.component import adapter 
+  from zope.interface import implementer
+
+  from plone.app.contenttypes.interfaces import INewsItem
+
+  @implementer(IAdditionalMetatags)
+  @adapter(INewsItem)
+  class MyAdditionalMetatags(object):
+
+      def __init__(self, context):
+          self.context = context
+
+      def metatags(self):
+          return {'my_key_1': 'my_value_1'}
+
+And in your configure.zcml file::
+    ...
+        <adapter
+            factory=".adapters.MyAdditionalMetatags"
+        />
+    ...
+
+
 Validation of best practices for social networks sharing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/sc/social/like/browser/templates/metadata.pt
+++ b/sc/social/like/browser/templates/metadata.pt
@@ -1,15 +1,6 @@
-<meta property="og:title" tal:attributes="content view/title" />
-<meta property="og:description" tal:attributes="content view/description" />
-<meta property="og:type" tal:attributes="content view/type" />
-<meta property="og:url" tal:attributes="content view/canonical_url" />
-<meta property="og:image" tal:attributes="content view/image_url" />
-<tal:image tal:condition="nocall:view/image">
-  <meta property="og:image:height" tal:attributes="content view/image_height" />
-  <meta property="og:image:width" tal:attributes="content view/image_width" />
-  <meta property="og:image:type" tal:attributes="content view/image_type" />
-</tal:image>
-<meta property="og:locale" tal:attributes="content view/language" />
-<meta property="og:site_name" tal:attributes="content view/site_name" />
+<tal:metatags repeat="tag view/metatags">
+  <meta property="" content="" tal:attributes="property python:tag[0]; content python:tag[1]" />
+</tal:metatags>
 
 <tal:plugin tal:repeat="plugin view/plugins">
   <tal:replace replace="structure plugin/html" />

--- a/sc/social/like/browser/viewlets.py
+++ b/sc/social/like/browser/viewlets.py
@@ -8,10 +8,12 @@ from plone.registry.interfaces import IRegistry
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from sc.social.like.behaviors import ISocialMedia
+from sc.social.like.interfaces import IAdditionalMetatags
 from sc.social.like.interfaces import ISocialLikeSettings
 from sc.social.like.plugins.facebook.utils import facebook_language
 from sc.social.like.utils import get_content_image
 from sc.social.like.utils import get_language
+from zope.component import getAdapters
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 
@@ -141,6 +143,24 @@ class SocialMetadataViewlet(BaseLikeViewlet):
         if context_state.is_portal_root():
             return 'website'
         return 'article'
+
+    def metatags(self):
+        tags = {}
+        tags['og:title'] = self.title
+        tags['og:description'] = self.description
+        tags['og:type'] = self.type()
+        tags['og:url'] = self.canonical_url()
+        tags['og:image'] = self.image_url()
+        if self.image:
+            tags['og:image:height'] = self.image_height()
+            tags['og:image:width'] = self.image_width()
+            tags['og:image:type'] = self.image_type()
+        tags['og:locale'] = self.language
+        tags['og:site_name'] = self.site_name
+
+        for _, adapter in getAdapters((self.context,), IAdditionalMetatags):
+            tags.update(adapter.metatags())
+        return tags.items()
 
 
 class SocialLikesViewlet(BaseLikeViewlet):

--- a/sc/social/like/interfaces.py
+++ b/sc/social/like/interfaces.py
@@ -249,3 +249,10 @@ class ISocialLikeSettings(model.Schema):
         required=False,
         default='',
     )
+
+
+class IAdditionalMetatags(Interface):
+    """ Interface to provide additional metatags to those provided by default """
+
+    def metatags():
+        """ a dict with additional metatags """

--- a/sc/social/like/tests/test_viewlets.py
+++ b/sc/social/like/tests/test_viewlets.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from plone import api
-from plone.app.contenttypes.interfaces import INewsItem
 from profilehooks import profile
 from profilehooks import timecall
 from sc.social.like.config import IS_PLONE_5
@@ -17,6 +16,12 @@ import contextlib
 import os
 import re
 import unittest
+
+
+try:
+    from plone.app.contenttypes.interfaces import INewsItem
+except ImportError:
+    from Products.ATContentTypes.interfaces import IATNewsItem as INewsItem
 
 
 # TODO: document this on README

--- a/sc/social/like/tests/test_viewlets.py
+++ b/sc/social/like/tests/test_viewlets.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 from plone import api
+from plone.app.contenttypes.interfaces import INewsItem
 from profilehooks import profile
 from profilehooks import timecall
 from sc.social.like.config import IS_PLONE_5
+from sc.social.like.interfaces import IAdditionalMetatags
 from sc.social.like.interfaces import ISocialLikeSettings
 from sc.social.like.testing import INTEGRATION_TESTING
 from sc.social.like.testing import load_image
 from sc.social.like.tests.api_hacks import set_image_field
+from zope.component import adapter
+from zope.component import provideAdapter
+from zope.interface import implementer
 
 import contextlib
 import os
@@ -19,6 +24,37 @@ import unittest
 skip_profiling = os.environ.get('SKIP_CODE_PROFILING', False)
 
 do_not_track = ISocialLikeSettings.__identifier__ + '.do_not_track'
+
+
+@implementer(IAdditionalMetatags)
+@adapter(INewsItem)
+class NewsItemMetatagsAdapter(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def metatags(self):
+        tags = {}
+        tags['one_key'] = 'one_value'
+        tags['two_key'] = 'two_value'
+        tags['three_key'] = 'three_value'
+
+        return tags
+
+
+@implementer(IAdditionalMetatags)
+@adapter(INewsItem)
+class NewsItemMetatagsAdapterOverridingTags(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def metatags(self):
+        tags = {}
+        tags['og:title'] = 'My overrided title'
+        tags['one_key'] = 'one_value'
+
+        return tags
 
 
 @contextlib.contextmanager
@@ -122,6 +158,25 @@ class MetadataViewletTestCase(ViewletBaseTestCase):
         self.assertIn('og:image:type', html)
         self.assertIn('og:locale', html)
         self.assertIn('og:site_name', html)
+
+    def test_additional_metadata_rendering(self):
+        provideAdapter(NewsItemMetatagsAdapter)
+        viewlet = self.viewlet(self.obj)
+        html = viewlet.render()
+        self.assertIn('one_key', html)
+        self.assertIn('one_value', html)
+        self.assertIn('two_key', html)
+        self.assertIn('two_value', html)
+        self.assertIn('three_key', html)
+        self.assertIn('three_value', html)
+
+    def test_additional_metadata_with_overriden_values_rendering(self):
+        provideAdapter(NewsItemMetatagsAdapterOverridingTags)
+        viewlet = self.viewlet(self.obj)
+        html = viewlet.render()
+        self.assertIn('My overrided title', html)
+        self.assertIn('one_key', html)
+        self.assertIn('one_value', html)
 
     @unittest.skipIf(skip_profiling, 'Skipping performance measure and code profiling')
     def test_metadata_viewlet_rendering_performance(self):


### PR DESCRIPTION
I needed a way to extend the default metadata provided by the product, and implemented it using adapters.

To extend the default metadata, you need to provide an adapter for the given content type and return a dict with the new metadata.

You can also override preexisting metadata (if you want to change for instance og:title or any other.

This idea of using an adapter comes from [collective.opengraph](https://github.com/collective/collective.opengraph) a preexisting product that provides just opengraph metadata support.

Any comments are welcomed, of course!