### PR TITLE
fix upgrade step when there are no plone.app.tiles records on registry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ There's a frood who really knows where his towel is.
 2.13b4 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Fix upgrade step when there are no plone.app.tiles recrods.
+  [erral]
 
 
 2.13b3 (2018-01-11)

--- a/sc/social/like/upgrades/v3041/__init__.py
+++ b/sc/social/like/upgrades/v3041/__init__.py
@@ -6,7 +6,8 @@ from sc.social.like.logger import logger
 
 def register_cover_tiles(setup_tool):
     """Register collective.cover tiles."""
-    registered = api.portal.get_registry_record('plone.app.tiles')
-    [registered.append(t) for t in TILES if t not in registered]
-    assert set(registered) & set(TILES) == set(TILES)
-    logger.info('Tiles for collective.cover were registered')
+    registered = api.portal.get_registry_record('plone.app.tiles', default=None)
+    if registered is not None:
+        [registered.append(t) for t in TILES if t not in registered]
+        assert set(registered) & set(TILES) == set(TILES)
+        logger.info('Tiles for collective.cover were registered')


### PR DESCRIPTION
Sorry, I had this fix forgotten.

This fixes #151 
