### PR TITLE
Log errors and proceed when reindexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ Makefile
 .pydevproject
 .project
 .settings
+
+# virtual environment:
+lib64
+pip-selfcheck.json


### PR DESCRIPTION
We have a ZODB which contains at least one object (after processing of 13000 objects) which can't be reindexed.

Of course we do want the remaining 50000 objects to be reindexed, and we'd like to know _which one_ causes the trouble.

Thus,
- we log the error, and
- we count the errors.

ZODB ConflictErrors are not handled that way (yet?) but re-raised.
