### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ services:
   - xvfb
 language: python
 python: 2.7
-sudo: false
 cache:
   directories:
   - $HOME/.pylint.d

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+services:
+  - xvfb
 language: python
 python: 2.7
 sudo: false
@@ -24,8 +26,6 @@ install:
 - bin/buildout buildout:test-eggs=$TEST_EGGS
 before_script:
 - export CATALOG_OPTIMIZATION_DISABLED=true
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 - firefox -v
 script:
 - bin/code-analysis


### PR DESCRIPTION
- Fix "Can't open /etc/init.d/xvfb" in Travis.

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

This has changed the execution format of xvfb:

https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui

- `sudo: false` is deprecated:

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
