### PR TITLE
Fix section title in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Don't Panic
 -----------
 
 Plone version compatibility
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 This package is compatible with Plone 4.3 and 5.0.
 


### PR DESCRIPTION
`~` isn't a valid character to define section title. See:

https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections