### PR TITLE
CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 - bin/pylint --py3k --disable=no-absolute-import sc/social/like
 after_success:
 - bin/zopepy setup.py check -mrs
-- pip install coverage==4.5.4
+- pip install coverage
 - coverage run bin/test --layer=\!Robot
 # Coveralls
 - pip install coveralls

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,8 +7,6 @@ extends =
 package-name = sc.social.like
 package-extras = [develop, test]
 
-newest = true
-
 parts +=
     code-analysis
     node


### PR DESCRIPTION
- Remove `newest = true`. `buildout.plonetest` remove `newest = false`.

- Unpinning `coverage` version. New version of `coverage` is compatible with `coveralls`.